### PR TITLE
[NCL-8801]: Fix configs (application.yaml-s)

### DIFF
--- a/src/main/java/org/jboss/pnc/reqour/common/gitlab/GitlabApiService.java
+++ b/src/main/java/org/jboss/pnc/reqour/common/gitlab/GitlabApiService.java
@@ -38,6 +38,7 @@ import org.jboss.pnc.reqour.config.GitBackendConfig;
 import org.jboss.pnc.reqour.model.GitlabGetOrCreateProjectResult;
 import org.jboss.pnc.reqour.rest.providers.GitlabApiRuntimeException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -160,7 +161,8 @@ public class GitlabApiService {
     public boolean doesTagProtectionAlreadyExist(Long projectId) {
         GitBackendConfig.TagProtectionConfig tagProtectionConfig = gitlabConfig.tagProtection();
         Optional<String> protectedTagsPattern = tagProtectionConfig.protectedTagsPattern();
-        List<String> protectedTagsAcceptedPatterns = tagProtectionConfig.protectedTagsAcceptedPatterns();
+        List<String> protectedTagsAcceptedPatterns = tagProtectionConfig.protectedTagsAcceptedPatterns()
+                .orElse(new ArrayList<>());
 
         if (protectedTagsPattern.isPresent() && !protectedTagsAcceptedPatterns.contains(protectedTagsPattern.get())) {
             protectedTagsAcceptedPatterns.add(protectedTagsPattern.get());

--- a/src/main/java/org/jboss/pnc/reqour/config/GitBackendConfig.java
+++ b/src/main/java/org/jboss/pnc/reqour/config/GitBackendConfig.java
@@ -54,6 +54,6 @@ public interface GitBackendConfig {
 
         Optional<String> protectedTagsPattern();
 
-        List<String> protectedTagsAcceptedPatterns();
+        Optional<List<String>> protectedTagsAcceptedPatterns();
     }
 }

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -15,7 +15,6 @@ reqour:
           read-write-template: git@${reqour.git.git-backends.available.gitlab.hostname}:${reqour.git.git-backends.available.gitlab.workspace}/%s.git
           protected-tags-pattern: '*'
           protected-tags-accepted-patterns:
-            - 'protected-'
       active: gitlab
     acceptable-schemes:
       - https

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,4 +8,12 @@ quarkus:
 
 reqour:
   git:
+    git-backends:
+      available:
+        gitlab:
+          url: https://${reqour.git.git-backends.available.gitlab.hostname}
+          git-url-internal-template: git@${reqour.git.git-backends.available.gitlab.hostname}:${reqour.git.git-backends.available.gitlab.workspace}
+          read-only-template: https://${reqour.git.git-backends.available.gitlab.hostname}/${reqour.git.git-backends.available.gitlab.workspace}/%s.git
+          read-write-template: git@${reqour.git.git-backends.available.gitlab.hostname}:${reqour.git.git-backends.available.gitlab.workspace}/%s.git
+          token: ${GITLAB_TOKEN}
     private-github-user: ${PRIVATE_GITHUB_USER}

--- a/src/test/java/org/jboss/pnc/reqour/common/TestDataSupplier.java
+++ b/src/test/java/org/jboss/pnc/reqour/common/TestDataSupplier.java
@@ -19,7 +19,6 @@ package org.jboss.pnc.reqour.common;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.config.ConfigProvider;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.gitlab4j.api.models.Group;
 import org.gitlab4j.api.models.Namespace;
 import org.gitlab4j.api.models.Project;
@@ -32,25 +31,12 @@ import org.jboss.pnc.reqour.config.GitBackendConfig;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 
 import static org.jboss.pnc.reqour.common.TestUtils.createTranslateRequestFromExternalUrl;
 import static org.jboss.pnc.reqour.common.TestUtils.createTranslateResponseFromExternalUrl;
 
 @ApplicationScoped
 public class TestDataSupplier {
-
-    @ConfigProperty(name = "reqour.git.git-backends.available.gitlab.workspace-id")
-    Long workspaceId;
-
-    @ConfigProperty(name = "reqour.git.git-backends.available.gitlab.workspace")
-    String workspaceName;
-
-    @ConfigProperty(name = "reqour.git.git-backends.available.gitlab.protected-tags-pattern")
-    Optional<String> protectedTagsPattern;
-
-    @ConfigProperty(name = "reqour.git.git-backends.available.gitlab.protected-tags-accepted-patterns")
-    List<String> protectedTagsAccepted;
 
     public static final String TASK_ID = "task-id";
 


### PR DESCRIPTION
Initially, the config value of `protected-tags-accepted-patterns` was of type `List<String>`. However, this results in build fail in case one provides `[]` as a value -- this is a known, already closed, issue in quarkus. The solution is to use `Optional<List<String>>` in such cases.

Also, prod `application.yaml` was split into 2 parts: static (=non-changing) config values are in `application.yaml`, and all runtime config values are present in runtime config.