### PR TITLE
[NCL-8828]: Introduce reqour adjuster module

### DIFF
--- a/adjuster/.gitignore
+++ b/adjuster/.gitignore
@@ -1,10 +1,3 @@
-# Ignore code-generated class that will change on every build
-core/src/main/java/org/jboss/pnc/reqour/BuildInformationConstants.java
-
-# Local runtime configs
-adjuster/config/
-rest/config/
-
 #Maven
 target/
 pom.xml.tag
@@ -48,3 +41,5 @@ nb-configuration.xml
 
 # Plugin directory
 /.quarkus/cli/plugins/
+# TLS Certificates
+.certs/

--- a/adjuster/pom.xml
+++ b/adjuster/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2024 Red Hat, Inc.
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>reqour-adjuster</artifactId>
+
+    <parent>
+        <groupId>org.jboss.pnc.reqour</groupId>
+        <artifactId>reqour-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+        <rootPath>..</rootPath>
+    </properties>
+
+    <dependencies>
+        <!-- Inter-module dependencies -->
+        <dependency>
+            <groupId>org.jboss.pnc.reqour</groupId>
+            <artifactId>reqour-core</artifactId>
+        </dependency>
+
+        <!-- Quarkus dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-picocli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-config-yaml</artifactId>
+        </dependency>
+
+        <!-- Regular dependencies -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <configuration>
+                    <finalName>reqour-adjuster</finalName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/adjuster/pom.xml
+++ b/adjuster/pom.xml
@@ -54,6 +54,12 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.jboss.pnc.reqour</groupId>
+            <artifactId>reqour-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/App.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/App.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.picocli.runtime.annotations.TopCommand;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.jboss.pnc.api.enums.BuildType;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.api.reqour.dto.AdjustResponse;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.adjust.provider.AdjustProvider;
+import org.jboss.pnc.reqour.adjust.provider.GradleProvider;
+import org.jboss.pnc.reqour.adjust.provider.MvnProvider;
+import org.jboss.pnc.reqour.adjust.provider.NpmProvider;
+import org.jboss.pnc.reqour.adjust.provider.SbtProvider;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+/**
+ * The entrypoint of the reqour adjuster.
+ */
+@TopCommand
+@CommandLine.Command(
+        name = "adjust",
+        description = "Execute the alignment with the corresponding built tool and manipulator",
+        mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider.class)
+@Slf4j
+public class App implements Callable<AdjustResponse> {
+
+    @Inject
+    ReqourAdjusterConfig config;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @CommandLine.Parameters(description = "Adjust type", arity = "1")
+    BuildType type;
+
+    @CommandLine.Option(
+            names = { "-i", "--input-file" },
+            description = "Location of the input file (with the request). If not present, defaults to what is int the config (see 'reqour-adjuster.input-location').",
+            arity = "0..1")
+    Path inputLocation;
+
+    private static AdjustConfig adjustConfig;
+    private static AdjustRequest adjustRequest;
+    private static final Path workdir = IOUtils.createTempDirForAdjust();
+
+    @Override
+    public AdjustResponse call() throws Exception {
+        adjustConfig = config.adjust();
+        adjustRequest = getAdjustRequest();
+        AdjustProvider adjustProvider = pickAdjustProvider();
+        AdjustResponse response = adjustProvider.adjust();
+        FileUtils.deleteDirectory(workdir.toFile());
+        return response;
+    }
+
+    @Produces
+    @ApplicationScoped
+    AdjustProvider pickAdjustProvider() {
+        return switch (type) {
+            case MVN -> new MvnProvider(adjustConfig, adjustRequest, workdir);
+            case NPM -> new NpmProvider(adjustConfig, adjustRequest, workdir);
+            case GRADLE -> new GradleProvider(adjustConfig, adjustRequest, workdir);
+            case SBT -> new SbtProvider(adjustConfig, adjustRequest, workdir);
+        };
+    }
+
+    private AdjustRequest getAdjustRequest() {
+        Path requestLocation = getInputFileLocation();
+        try {
+            AdjustRequest request = objectMapper.readValue(requestLocation.toFile(), AdjustRequest.class);
+            log.debug("Parsed request: {}", request);
+            return request;
+        } catch (IOException e) {
+            throw new RuntimeException("Error occurred when reading the request from file " + requestLocation, e);
+        }
+    }
+
+    private Path getInputFileLocation() {
+        if (inputLocation == null) {
+            log.debug(
+                    "Input file not specified as CLI argument. Hence, using the default input location from the config: {}",
+                    config.inputLocation());
+            return config.inputLocation();
+        }
+
+        log.debug("Input file CLI argument specified as: {}", inputLocation);
+        return inputLocation;
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/VersionProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/VersionProvider.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.pnc.reqour.BuildInformationConstants;
+import picocli.CommandLine;
+
+@ApplicationScoped
+public class VersionProvider implements CommandLine.IVersionProvider {
+
+    @Override
+    public String[] getVersion() throws Exception {
+        return new String[] { "Reqour Adjuster", printVersionAttribute("Version", BuildInformationConstants.VERSION),
+                printVersionAttribute("Commit hash", BuildInformationConstants.COMMIT_HASH),
+                printVersionAttribute("Build time", BuildInformationConstants.BUILD_TIME) };
+    }
+
+    private static String printVersionAttribute(String name, String value) {
+        return String.format("\t%s: \t%s", name, value);
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/AdjustConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/AdjustConfig.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import io.smallrye.config.WithName;
+
+import java.util.Map;
+
+/**
+ * Alignment configuration.
+ */
+public interface AdjustConfig {
+
+    @WithName("mvn")
+    MvnProviderConfig mvnProviderConfig();
+
+    @WithName("gradle")
+    GradleProviderConfig gradleProviderConfig();
+
+    @WithName("scala")
+    SbtProviderConfig scalaProviderConfig();
+
+    @WithName("npm")
+    NpmProviderConfig npmProviderConfig();
+
+    Map<String, BuildCategoryConfig> buildCategories();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/BuildCategoryConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/BuildCategoryConfig.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import java.util.Optional;
+
+/**
+ * Configuration for {@link org.jboss.pnc.api.constants.BuildConfigurationParameterKeys#BUILD_CATEGORY}.
+ */
+public interface BuildCategoryConfig {
+
+    String persistentMode();
+
+    String temporaryMode();
+
+    String temporaryPreferPersistentMode();
+
+    Optional<String> prefixOfSuffixVersion();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/GradleProviderConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/GradleProviderConfig.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Configuration for {@link org.jboss.pnc.reqour.adjust.provider.GradleProvider}.
+ */
+public interface GradleProviderConfig {
+
+    Path gradleAnalyzerPluginInitFilePath();
+
+    Path cliJarPath();
+
+    Path defaultGradlePath();
+
+    List<String> alignmentParameters();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/MvnProviderConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/MvnProviderConfig.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Configuration for {@link org.jboss.pnc.reqour.adjust.provider.MvnProvider}.
+ */
+public interface MvnProviderConfig {
+
+    Path cliJarPath();
+
+    Path defaultSettingsFilePath();
+
+    Path temporarySettingsFilePath();
+
+    List<String> alignmentParameters();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/NpmProviderConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/NpmProviderConfig.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Configuration for {@link org.jboss.pnc.reqour.adjust.provider.NpmProvider}.
+ */
+public interface NpmProviderConfig {
+
+    Path cliJarPath();
+
+    List<String> alignmentParameters();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/ReqourAdjusterConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/ReqourAdjusterConfig.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import io.smallrye.config.ConfigMapping;
+
+import java.nio.file.Path;
+
+/**
+ * Configuration for the whole Reqour adjuster module.
+ */
+@ConfigMapping(prefix = "reqour-adjuster")
+public interface ReqourAdjusterConfig {
+
+    /**
+     * Location of the input request. This is identical request as is obtained in the {@code POST /adjust} endpoint of
+     * the {@code reqour-rest} module.
+     */
+    Path inputLocation();
+
+    AdjustConfig adjust();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/SbtProviderConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/SbtProviderConfig.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Configuration for {@link org.jboss.pnc.reqour.adjust.provider.SbtProvider}.
+ */
+public interface SbtProviderConfig {
+
+    Path sbtPath();
+
+    List<String> alignmentParameters();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/GmeConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/GmeConfig.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config.manipulator;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.SuperBuilder;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfig;
+
+import java.nio.file.Path;
+
+/**
+ * Configuration of the gradle manipulator (GME).
+ */
+@SuperBuilder(toBuilder = true)
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class GmeConfig extends CommonManipulatorConfig {
+
+    Path gradleAnalyzerPluginInitFilePath;
+
+    Path cliJarPath;
+
+    Path defaultGradlePath;
+
+    boolean isBrewPullEnabled;
+
+    boolean preferPersistentEnabled;
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/PmeConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/PmeConfig.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config.manipulator;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.SuperBuilder;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfig;
+
+import java.nio.file.Path;
+
+/**
+ * Configuration of the pom manipulator (PME).
+ */
+@SuperBuilder(toBuilder = true)
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class PmeConfig extends CommonManipulatorConfig {
+
+    Path cliJarPath;
+
+    Path settingsFilePath;
+
+    boolean isBrewPullEnabled;
+
+    boolean preferPersistentEnabled;
+
+    Path subFolderWithAlignmentFile;
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/ProjectManipulatorConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/ProjectManipulatorConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config.manipulator;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.SuperBuilder;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfig;
+
+import java.nio.file.Path;
+
+/**
+ * Configuration of the project manipulator.
+ */
+@SuperBuilder(toBuilder = true)
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class ProjectManipulatorConfig extends CommonManipulatorConfig {
+
+    Path cliJarPath;
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/SmegConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/SmegConfig.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config.manipulator;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.SuperBuilder;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfig;
+
+import java.nio.file.Path;
+
+/**
+ * Configuration of the Sbt Manipulator Extension pluGin (SMEG).
+ */
+@SuperBuilder(toBuilder = true)
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class SmegConfig extends CommonManipulatorConfig {
+
+    Path sbtPath;
+
+    boolean brewPullEnabled;
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/common/CommonManipulatorConfig.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/common/CommonManipulatorConfig.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config.manipulator.common;
+
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import lombok.experimental.SuperBuilder;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Config, which is common for all the manipulators.
+ */
+@SuperBuilder(toBuilder = true)
+@NonFinal
+@Value
+public class CommonManipulatorConfig {
+
+    /**
+     * Default alignment parameters set by PNC. Users can of course override these defaults, e.g. see
+     * {@link this#userSpecifiedAlignmentParameters}.
+     */
+    List<String> pncDefaultAlignmentParameters;
+
+    /**
+     * User-specified alignment parameters from build parameters, see
+     * {@link org.jboss.pnc.api.constants.BuildConfigurationParameterKeys#ALIGNMENT_PARAMETERS}.
+     */
+    List<String> userSpecifiedAlignmentParameters;
+
+    /**
+     * Alignment parameters from the config. These alignment parameters define properties crucial for correct working of
+     * the alignment phase, e.g. the REST URL of the DA, which cannot be overridden by user from obvious reasons.
+     */
+    List<String> alignmentConfigParameters;
+
+    /**
+     * REST mode
+     */
+    String restMode;
+
+    /**
+     * Prefix of the build suffix version, e.g. 'redhat-'.
+     */
+    String prefixOfVersionSuffix;
+
+    /**
+     * Working directory, in which should the manipulator run.
+     */
+    Path workdir;
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/common/CommonManipulatorConfigUtils.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/manipulator/common/CommonManipulatorConfigUtils.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.config.manipulator.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.jboss.pnc.api.constants.BuildConfigurationParameterKeys;
+import org.jboss.pnc.api.enums.AlignmentPreference;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.BuildCategoryConfig;
+import org.jboss.pnc.reqour.adjust.exception.InvalidConfigException;
+import org.jboss.pnc.reqour.adjust.model.UserSpecifiedAlignmentParameters;
+import org.jboss.pnc.reqour.adjust.model.LocationAndRemainingArgsOptions;
+
+import javax.validation.constraints.NotNull;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.jboss.pnc.api.constants.BuildConfigurationParameterKeys.ALIGNMENT_PARAMETERS;
+
+@Slf4j
+public class CommonManipulatorConfigUtils {
+
+    private static final String TEMPORARY_SUFFIX = "temporary";
+    private static final String FILE_ARG_NAME = "file";
+
+    public static List<String> transformPncDefaultAlignmentParametersIntoList(AdjustRequest request) {
+        String pncDefaultAlignmentParameters = request.getPncDefaultAlignmentParameters();
+        if (pncDefaultAlignmentParameters == null) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.asList(pncDefaultAlignmentParameters.split(" "));
+    }
+
+    public static UserSpecifiedAlignmentParameters parseUserSpecifiedAlignmentParameters(AdjustRequest request) {
+        return parseUserSpecifiedAlignmentParameters(request, "f", "file");
+    }
+
+    public static UserSpecifiedAlignmentParameters parseUserSpecifiedAlignmentParameters(
+            AdjustRequest request,
+            @NotNull String locationShortOption,
+            @NotNull String locationLongOption) {
+        Map<BuildConfigurationParameterKeys, String> buildConfigParameters = request.getBuildConfigParameters();
+        String userSpecifiedAlignmentParameters = buildConfigParameters.get(ALIGNMENT_PARAMETERS);
+
+        if (userSpecifiedAlignmentParameters == null) {
+            return UserSpecifiedAlignmentParameters.defaultResult();
+        }
+
+        LocationAndRemainingArgsOptions optionsSplitted = extractLocationFromUsersAlignmentParameters(
+                userSpecifiedAlignmentParameters,
+                locationShortOption,
+                locationLongOption);
+
+        if (optionsSplitted.getLocationOption().isEmpty()) {
+            return UserSpecifiedAlignmentParameters.withoutSubFolder(userSpecifiedAlignmentParameters);
+        }
+
+        CommandLineParser parser = new DefaultParser();
+        final Options options = new Options();
+        options.addOption(
+                Option.builder()
+                        .option(locationShortOption)
+                        .longOpt(locationLongOption)
+                        .argName(FILE_ARG_NAME)
+                        .hasArg()
+                        .valueSeparator()
+                        .build());
+        try {
+            CommandLine parseResult = parser.parse(options, optionsSplitted.getLocationOption().get().split(" "));
+            return UserSpecifiedAlignmentParameters.builder()
+                    .alignmentParameters(optionsSplitted.getRemainingArgs())
+                    .subFolder(extractFolderFromFile(parseResult.getOptionValue(FILE_ARG_NAME)))
+                    .build();
+        } catch (ParseException e) {
+            log.warn("Could not parse alignment parameters, returning default");
+            return UserSpecifiedAlignmentParameters.defaultResult();
+        }
+    }
+
+    public static List<String> getExtraAdjustmentParameters(AdjustRequest adjustRequest) {
+        Map<BuildConfigurationParameterKeys, String> buildConfigParameters = adjustRequest.getBuildConfigParameters();
+        String userSpecifiedAlignmentParameters = buildConfigParameters.getOrDefault(ALIGNMENT_PARAMETERS, "");
+
+        List<String> parametersSplitted = List.of(userSpecifiedAlignmentParameters.split(" "));
+        if (parametersSplitted.stream().anyMatch(Predicate.not(p -> p.startsWith("-")))) {
+            throw new InvalidConfigException(
+                    "Parameters which do not start with '-' are not allowed. Given: '"
+                            + userSpecifiedAlignmentParameters + "'.");
+        }
+
+        return parametersSplitted;
+    }
+
+    public static String computePrefixOfVersionSuffix(AdjustRequest request, AdjustConfig adjustConfig) {
+        BuildCategoryConfig buildCategoryConfig = getBuildCategoryConfig(request, adjustConfig);
+
+        if (request.isTempBuild()) {
+            return buildCategoryConfig.prefixOfSuffixVersion().map(s -> s + "-").orElse("") + TEMPORARY_SUFFIX;
+        }
+        return buildCategoryConfig.prefixOfSuffixVersion().orElse("");
+    }
+
+    public static String stripTemporarySuffix(String prefixOfSuffix) {
+        var suffixWithoutTemporary = prefixOfSuffix.replace(TEMPORARY_SUFFIX, "");
+        return (suffixWithoutTemporary.endsWith("-"))
+                ? suffixWithoutTemporary.substring(0, suffixWithoutTemporary.length() - 1)
+                : suffixWithoutTemporary;
+    }
+
+    public static String computeRestMode(AdjustRequest request, AdjustConfig adjustConfig) {
+        BuildCategoryConfig buildCategoryConfig = getBuildCategoryConfig(request, adjustConfig);
+        boolean isTempBuild = request.isTempBuild();
+        boolean preferPersistent = isPreferPersistentEnabled(request);
+
+        if (isTempBuild && preferPersistent) {
+            return buildCategoryConfig.temporaryPreferPersistentMode();
+        }
+        if (isTempBuild) {
+            return buildCategoryConfig.temporaryMode();
+        }
+        return buildCategoryConfig.persistentMode();
+    }
+
+    public static boolean isBrewPullEnabled(AdjustRequest request) {
+        return request.isBrewPullActive();
+    }
+
+    public static boolean isPreferPersistentEnabled(AdjustRequest request) {
+        return AlignmentPreference.PREFER_PERSISTENT.equals(request.getAlignmentPreference());
+    }
+
+    public static Path getJvmLocation(List<String> userSpecifiedAlignmentParameters) {
+        Optional<String> jvmLocationSystemProperty = userSpecifiedAlignmentParameters.stream()
+                .filter(p -> p.startsWith("-DRepour_Java"))
+                .findFirst();
+        if (jvmLocationSystemProperty.isEmpty()) {
+            return Path.of("java");
+        }
+
+        int jvmVersion = Integer.parseInt(jvmLocationSystemProperty.get().split("=")[1]);
+        return Path.of("/usr", "lib", "jvm", "java-" + jvmVersion + "-openjdk", "bin", "java");
+    }
+
+    private static BuildCategoryConfig getBuildCategoryConfig(AdjustRequest request, AdjustConfig adjustConfig) {
+        String buildCategory = request.getBuildConfigParameters()
+                .getOrDefault(BuildConfigurationParameterKeys.BUILD_CATEGORY, "STANDARD");
+        BuildCategoryConfig buildCategoryConfig = adjustConfig.buildCategories().get(buildCategory);
+
+        if (buildCategoryConfig == null) {
+            log.warn("Got unknown build category: {}", buildCategory);
+            throw new IllegalArgumentException("Unknown build category specified");
+        }
+
+        return buildCategoryConfig;
+    }
+
+    private static LocationAndRemainingArgsOptions extractLocationFromUsersAlignmentParameters(
+            String userSpecifiedAlignmentParameters,
+            String locationShortOption,
+            String locationLongOption) {
+        String regex = String.format(
+                "^.*(-%s=\\S+|-%s \\S+|--%s=\\S+|--%s \\S+).*$",
+                locationShortOption,
+                locationShortOption,
+                locationLongOption,
+                locationShortOption);
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(userSpecifiedAlignmentParameters);
+
+        if (matcher.matches()) {
+            return LocationAndRemainingArgsOptions.builder()
+                    .locationOption(Optional.of(matcher.group(1)))
+                    .remainingArgs(
+                            Stream.of(userSpecifiedAlignmentParameters.replace(matcher.group(1), ""))
+                                    .filter(Predicate.not(String::isBlank))
+                                    .toList())
+                    .build();
+        }
+
+        return LocationAndRemainingArgsOptions.builder()
+                .locationOption(Optional.empty())
+                .remainingArgs(List.of(userSpecifiedAlignmentParameters.split(" ")))
+                .build();
+    }
+
+    private static Path extractFolderFromFile(String filePath) {
+        log.debug("Extracting folder from {}", filePath);
+
+        if (filePath == null || !filePath.contains("/")) {
+            return Path.of("");
+        }
+
+        return Path.of(filePath.substring(0, filePath.lastIndexOf("/")));
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/exception/InvalidConfigException.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/exception/InvalidConfigException.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.exception;
+
+public class InvalidConfigException extends RuntimeException {
+
+    public InvalidConfigException(String message) {
+        super(message);
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/model/LocationAndRemainingArgsOptions.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/model/LocationAndRemainingArgsOptions.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+import java.util.Optional;
+
+@Builder
+@Value
+public class LocationAndRemainingArgsOptions {
+
+    Optional<String> locationOption;
+    List<String> remainingArgs;
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/model/UserSpecifiedAlignmentParameters.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/model/UserSpecifiedAlignmentParameters.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * User specified alignment parameters, i.e., parameters provided in
+ * {@link org.jboss.pnc.api.constants.BuildConfigurationParameterKeys#ALIGNMENT_PARAMETERS}.
+ */
+@Builder
+@Value
+public class UserSpecifiedAlignmentParameters {
+
+    private static final Path DEFAULT_SUB_FOLDER = Path.of("");
+
+    List<String> alignmentParameters;
+    Path subFolder;
+
+    public static UserSpecifiedAlignmentParameters defaultResult() {
+        return UserSpecifiedAlignmentParameters.builder()
+                .alignmentParameters(Collections.emptyList())
+                .subFolder(DEFAULT_SUB_FOLDER)
+                .build();
+    }
+
+    public static UserSpecifiedAlignmentParameters withoutSubFolder(String alignmentParameters) {
+        return UserSpecifiedAlignmentParameters.builder()
+                .alignmentParameters(Arrays.asList(alignmentParameters.split(" ")))
+                .subFolder(DEFAULT_SUB_FOLDER)
+                .build();
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/AbstractAdjustProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/AbstractAdjustProvider.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.api.reqour.dto.AdjustResponse;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfig;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * TODO: Write Javadoc once process executor is used in {@link this#adjust()}.
+ */
+@Slf4j
+public abstract class AbstractAdjustProvider<T extends CommonManipulatorConfig> implements AdjustProvider {
+
+    protected List<String> preparedCommand;
+    protected T config;
+
+    public AbstractAdjustProvider(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        init(adjustConfig, adjustRequest, workdir);
+        validateConfig();
+        preparedCommand = prepareCommand();
+        log.debug("Generated command: {}", preparedCommand);
+    }
+
+    abstract void init(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir);
+
+    abstract void validateConfig();
+
+    /**
+     * Prepare the shell command based on the config.
+     *
+     * @return array representing bash command
+     */
+    abstract List<String> prepareCommand();
+
+    @Override
+    public AdjustResponse adjust() {
+        return null;
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/AdjustProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/AdjustProvider.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import org.jboss.pnc.api.reqour.dto.AdjustResponse;
+
+/**
+ * Interface for providing alignment for any {@link org.jboss.pnc.api.enums.BuildType}.
+ */
+public interface AdjustProvider {
+
+    /**
+     * Make the alignment.
+     *
+     * @return result of alignment operation
+     */
+    AdjustResponse adjust();
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/GradleProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/GradleProvider.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.GradleProviderConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.GmeConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfigUtils;
+import org.jboss.pnc.reqour.adjust.model.UserSpecifiedAlignmentParameters;
+import org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils;
+import org.jboss.pnc.reqour.adjust.utils.InvalidConfigUtils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.BREW_PULL_ACTIVE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.REST_MODE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.VERSION_INCREMENTAL_SUFFIX;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.VERSION_SUFFIX_ALTERNATIVES;
+
+/**
+ * Provider for {@link org.jboss.pnc.api.enums.BuildType#GRADLE} builds.
+ */
+@Slf4j
+public class GradleProvider extends AbstractAdjustProvider<GmeConfig> implements AdjustProvider {
+
+    public GradleProvider(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        super(adjustConfig, adjustRequest, workdir);
+    }
+
+    @Override
+    public void init(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        GradleProviderConfig gradleProviderConfig = adjustConfig.gradleProviderConfig();
+
+        UserSpecifiedAlignmentParameters userSpecifiedAlignmentParameters = CommonManipulatorConfigUtils
+                .parseUserSpecifiedAlignmentParameters(adjustRequest, "t", "target");
+
+        config = GmeConfig.builder()
+                .pncDefaultAlignmentParameters(
+                        CommonManipulatorConfigUtils.transformPncDefaultAlignmentParametersIntoList(adjustRequest))
+                .userSpecifiedAlignmentParameters(userSpecifiedAlignmentParameters.getAlignmentParameters())
+                .restMode(CommonManipulatorConfigUtils.computeRestMode(adjustRequest, adjustConfig))
+                .prefixOfVersionSuffix(
+                        CommonManipulatorConfigUtils.computePrefixOfVersionSuffix(adjustRequest, adjustConfig))
+                .alignmentConfigParameters(gradleProviderConfig.alignmentParameters())
+                .workdir(workdir.resolve(userSpecifiedAlignmentParameters.getSubFolder()))
+                .gradleAnalyzerPluginInitFilePath(gradleProviderConfig.gradleAnalyzerPluginInitFilePath())
+                .cliJarPath(gradleProviderConfig.cliJarPath())
+                .defaultGradlePath(gradleProviderConfig.defaultGradlePath())
+                .isBrewPullEnabled(CommonManipulatorConfigUtils.isBrewPullEnabled(adjustRequest))
+                .preferPersistentEnabled(CommonManipulatorConfigUtils.isPreferPersistentEnabled(adjustRequest))
+                .build();
+    }
+
+    @Override
+    public void validateConfig() {
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getGradleAnalyzerPluginInitFilePath(),
+                "Gradle init file (specified as '%s') does not exist");
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getCliJarPath(),
+                "CLI jar file (specified as '%s') does not exist");
+        InvalidConfigUtils
+                .validateResourceAtPathExists(config.getWorkdir(), "Directory '%s' set as working does not exist");
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getDefaultGradlePath(),
+                "Specified gradle path '%s' is non-existent");
+
+        log.debug("The config was successfully initialized and validated: {}", config);
+    }
+
+    @Override
+    public List<String> prepareCommand() {
+        List<String> computedAlignmentParameters = getComputedAlignmentParameters();
+        Path jvmLocation = CommonManipulatorConfigUtils.getJvmLocation(config.getUserSpecifiedAlignmentParameters());
+        List<String> targetAndInit = getTargetAndInit();
+
+        return AdjustmentSystemPropertiesUtils.joinSystemPropertiesListsIntoList(
+                List.of(
+                        List.of(jvmLocation.toString(), "-jar", config.getCliJarPath().toString()),
+                        targetAndInit,
+                        config.getPncDefaultAlignmentParameters(),
+                        config.getUserSpecifiedAlignmentParameters(),
+                        config.getAlignmentConfigParameters(),
+                        computedAlignmentParameters));
+    }
+
+    private List<String> getComputedAlignmentParameters() {
+        final List<String> alignmentParameters = new ArrayList<>();
+
+        alignmentParameters
+                .add(AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(REST_MODE, config.getRestMode()));
+        if (!config.getPrefixOfVersionSuffix().isBlank()) {
+            alignmentParameters.add(
+                    AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(
+                            VERSION_INCREMENTAL_SUFFIX,
+                            config.getPrefixOfVersionSuffix() + "-redhat"));
+        }
+        alignmentParameters.add(
+                AdjustmentSystemPropertiesUtils
+                        .createAdjustmentSystemProperty(BREW_PULL_ACTIVE, config.isBrewPullEnabled()));
+
+        String prefixOfSuffixWithoutTemporary = CommonManipulatorConfigUtils
+                .stripTemporarySuffix(config.getPrefixOfVersionSuffix());
+        if (config.isPreferPersistentEnabled() && !prefixOfSuffixWithoutTemporary.isBlank()) {
+            alignmentParameters.add(
+                    AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(
+                            VERSION_SUFFIX_ALTERNATIVES,
+                            "redhat," + prefixOfSuffixWithoutTemporary + "-redhat"));
+        }
+
+        return alignmentParameters;
+    }
+
+    private List<String> getTargetAndInit() {
+        List<String> targetAndInit = new ArrayList<>(
+                List.of(
+                        "--target",
+                        config.getWorkdir().toString(),
+                        "--init-script",
+                        config.getGradleAnalyzerPluginInitFilePath().toString()));
+
+        if (!gradleWrapperSpecified()) {
+            targetAndInit.addAll(List.of("-l", config.getDefaultGradlePath().toString()));
+        }
+
+        return targetAndInit;
+    }
+
+    private boolean gradleWrapperSpecified() {
+        return Files.exists(config.getWorkdir().resolve("gradlew"));
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/MvnProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/MvnProvider.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.MvnProviderConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.PmeConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfigUtils;
+import org.jboss.pnc.reqour.adjust.model.UserSpecifiedAlignmentParameters;
+import org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils;
+import org.jboss.pnc.reqour.adjust.utils.InvalidConfigUtils;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.BREW_PULL_ACTIVE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.REST_MODE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.VERSION_INCREMENTAL_SUFFIX;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.VERSION_SUFFIX_ALTERNATIVES;
+
+/**
+ * Provider for {@link org.jboss.pnc.api.enums.BuildType#MVN} builds.
+ */
+@Slf4j
+public class MvnProvider extends AbstractAdjustProvider<PmeConfig> implements AdjustProvider {
+
+    public MvnProvider(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        super(adjustConfig, adjustRequest, workdir);
+    }
+
+    @Override
+    public void init(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        MvnProviderConfig mvnProviderConfig = adjustConfig.mvnProviderConfig();
+        UserSpecifiedAlignmentParameters userSpecifiedAlignmentParameters = CommonManipulatorConfigUtils
+                .parseUserSpecifiedAlignmentParameters(adjustRequest);
+
+        config = PmeConfig.builder()
+                .pncDefaultAlignmentParameters(
+                        CommonManipulatorConfigUtils.transformPncDefaultAlignmentParametersIntoList(adjustRequest))
+                .userSpecifiedAlignmentParameters(userSpecifiedAlignmentParameters.getAlignmentParameters())
+                .restMode(CommonManipulatorConfigUtils.computeRestMode(adjustRequest, adjustConfig))
+                .prefixOfVersionSuffix(
+                        CommonManipulatorConfigUtils.computePrefixOfVersionSuffix(adjustRequest, adjustConfig))
+                .alignmentConfigParameters(mvnProviderConfig.alignmentParameters())
+                .workdir(workdir)
+                .subFolderWithAlignmentFile(workdir.resolve(userSpecifiedAlignmentParameters.getSubFolder()))
+                .cliJarPath(mvnProviderConfig.cliJarPath())
+                .settingsFilePath(
+                        getPathToSettingsFile(
+                                adjustRequest,
+                                mvnProviderConfig.defaultSettingsFilePath(),
+                                mvnProviderConfig.temporarySettingsFilePath()))
+                .isBrewPullEnabled(CommonManipulatorConfigUtils.isBrewPullEnabled(adjustRequest))
+                .preferPersistentEnabled(CommonManipulatorConfigUtils.isPreferPersistentEnabled(adjustRequest))
+                .build();
+    }
+
+    private Path getPathToSettingsFile(
+            AdjustRequest adjustRequest,
+            Path defaultSettingsFilePath,
+            Path temporarySettingsFilePath) {
+        return (adjustRequest.isTempBuild()) ? temporarySettingsFilePath : defaultSettingsFilePath;
+    }
+
+    @Override
+    public void validateConfig() {
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getCliJarPath(),
+                "CLI jar file (specified at '%s') does not exist");
+
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getSettingsFilePath(),
+                "File with default settings (specified at '%s') does not exist");
+
+        log.debug("The config was successfully initialized and validated: {}", config);
+    }
+
+    @Override
+    public List<String> prepareCommand() {
+        List<String> userSpecifiedAlignmentParameters = config.getUserSpecifiedAlignmentParameters();
+        if (!config.getSubFolderWithAlignmentFile().equals(config.getWorkdir())) {
+            userSpecifiedAlignmentParameters.add("--file=" + config.getSubFolderWithAlignmentFile());
+        }
+        Path jvmLocation = CommonManipulatorConfigUtils.getJvmLocation(userSpecifiedAlignmentParameters);
+
+        return AdjustmentSystemPropertiesUtils.joinSystemPropertiesListsIntoList(
+                List.of(
+                        List.of(jvmLocation.toString(), "-jar", config.getCliJarPath().toString()),
+                        getPmeSettingsParameter(),
+                        config.getPncDefaultAlignmentParameters(),
+                        config.getUserSpecifiedAlignmentParameters(),
+                        config.getAlignmentConfigParameters(),
+                        getComputedAlignmentParameters()));
+    }
+
+    private List<String> getPmeSettingsParameter() {
+        return List.of("-s", config.getSettingsFilePath().toString());
+    }
+
+    private List<String> getComputedAlignmentParameters() {
+        final List<String> alignmentParameters = new ArrayList<>();
+
+        alignmentParameters
+                .add(AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(REST_MODE, config.getRestMode()));
+        if (!config.getPrefixOfVersionSuffix().isBlank()) {
+            alignmentParameters.add(
+                    AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(
+                            VERSION_INCREMENTAL_SUFFIX,
+                            config.getPrefixOfVersionSuffix() + "-redhat"));
+        }
+
+        String prefixOfSuffixWithoutTemporary = CommonManipulatorConfigUtils
+                .stripTemporarySuffix(config.getPrefixOfVersionSuffix());
+        if (config.isPreferPersistentEnabled() && !prefixOfSuffixWithoutTemporary.isBlank()) {
+            alignmentParameters.add(
+                    AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(
+                            VERSION_SUFFIX_ALTERNATIVES,
+                            "redhat," + prefixOfSuffixWithoutTemporary + "-redhat"));
+        }
+
+        alignmentParameters.add(
+                AdjustmentSystemPropertiesUtils
+                        .createAdjustmentSystemProperty(BREW_PULL_ACTIVE, config.isBrewPullEnabled()));
+
+        return alignmentParameters;
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/NpmProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/NpmProvider.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.NpmProviderConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.ProjectManipulatorConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfigUtils;
+import org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils;
+import org.jboss.pnc.reqour.adjust.utils.InvalidConfigUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.REST_MODE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.VERSION_INCREMENTAL_SUFFIX;
+
+/**
+ * Provider for {@link org.jboss.pnc.api.enums.BuildType#NPM} builds.
+ */
+@Slf4j
+public class NpmProvider extends AbstractAdjustProvider<ProjectManipulatorConfig> implements AdjustProvider {
+
+    public NpmProvider(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        super(adjustConfig, adjustRequest, workdir);
+    }
+
+    @Override
+    public void init(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        NpmProviderConfig npmProviderConfig = adjustConfig.npmProviderConfig();
+
+        config = ProjectManipulatorConfig.builder()
+                .pncDefaultAlignmentParameters(
+                        CommonManipulatorConfigUtils.transformPncDefaultAlignmentParametersIntoList(adjustRequest))
+                .userSpecifiedAlignmentParameters(
+                        CommonManipulatorConfigUtils.getExtraAdjustmentParameters(adjustRequest))
+                .restMode(CommonManipulatorConfigUtils.computeRestMode(adjustRequest, adjustConfig))
+                .prefixOfVersionSuffix(
+                        CommonManipulatorConfigUtils.computePrefixOfVersionSuffix(adjustRequest, adjustConfig))
+                .alignmentConfigParameters(npmProviderConfig.alignmentParameters())
+                .workdir(workdir)
+                .cliJarPath(npmProviderConfig.cliJarPath())
+                .build();
+
+        log.debug("Successfully initialized, project manipulator config: {}", config);
+    }
+
+    @Override
+    public void validateConfig() {
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getCliJarPath(),
+                "CLI jar file (specified as '%s') does not exist");
+    }
+
+    @Override
+    public List<String> prepareCommand() {
+        Path resultsFile;
+        try {
+            resultsFile = Files.createFile(Path.of("/tmp").resolve("results" + getGeneratedNumberFromWorkdir()));
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot create results file", e);
+        }
+
+        return AdjustmentSystemPropertiesUtils.joinSystemPropertiesListsIntoList(
+                List.of(
+                        List.of("java", "-jar", config.getCliJarPath().toString()),
+                        config.getPncDefaultAlignmentParameters(),
+                        config.getUserSpecifiedAlignmentParameters(),
+                        config.getAlignmentConfigParameters(),
+                        getComputedAlignmentParameters(),
+                        List.of("--result=" + resultsFile)));
+    }
+
+    private List<String> getComputedAlignmentParameters() {
+        final List<String> alignmentParameters = new ArrayList<>();
+
+        alignmentParameters
+                .add(AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(REST_MODE, config.getRestMode()));
+        if (!config.getPrefixOfVersionSuffix().isBlank()) {
+            Optional<String> originalSuffix = AdjustmentSystemPropertiesUtils.getSystemPropertyValue(
+                    VERSION_INCREMENTAL_SUFFIX,
+                    AdjustmentSystemPropertiesUtils.joinSystemPropertiesListsIntoStream(
+                            List.of(
+                                    config.getAlignmentConfigParameters(),
+                                    config.getUserSpecifiedAlignmentParameters(),
+                                    config.getPncDefaultAlignmentParameters())));
+            String newSuffix = originalSuffix.map(s -> "-" + s).orElse("");
+            alignmentParameters.add(
+                    AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(
+                            VERSION_INCREMENTAL_SUFFIX,
+                            config.getPrefixOfVersionSuffix() + newSuffix));
+        }
+
+        return alignmentParameters;
+    }
+
+    private String getGeneratedNumberFromWorkdir() {
+        Pattern p = Pattern.compile("^.*?(\\d+).*$");
+        Matcher m = p.matcher(config.getWorkdir().toString());
+
+        if (m.matches()) {
+            return "-" + m.group(1);
+        }
+        return "";
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/SbtProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/SbtProvider.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.adjust.config.AdjustConfig;
+import org.jboss.pnc.reqour.adjust.config.SbtProviderConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.SmegConfig;
+import org.jboss.pnc.reqour.adjust.config.manipulator.common.CommonManipulatorConfigUtils;
+import org.jboss.pnc.reqour.adjust.model.UserSpecifiedAlignmentParameters;
+import org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils;
+import org.jboss.pnc.reqour.adjust.utils.InvalidConfigUtils;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.BREW_PULL_ACTIVE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.REST_MODE;
+import static org.jboss.pnc.reqour.adjust.utils.AdjustmentSystemPropertiesUtils.AdjustmentSystemPropertyName.VERSION_INCREMENTAL_SUFFIX;
+
+/**
+ * Provider for {@link org.jboss.pnc.api.enums.BuildType#SBT} builds.
+ */
+@Slf4j
+public class SbtProvider extends AbstractAdjustProvider<SmegConfig> implements AdjustProvider {
+
+    public SbtProvider(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        super(adjustConfig, adjustRequest, workdir);
+    }
+
+    @Override
+    public void init(AdjustConfig adjustConfig, AdjustRequest adjustRequest, Path workdir) {
+        SbtProviderConfig sbtProviderConfig = adjustConfig.scalaProviderConfig();
+        UserSpecifiedAlignmentParameters userSpecifiedAlignmentParameters = CommonManipulatorConfigUtils
+                .parseUserSpecifiedAlignmentParameters(adjustRequest);
+
+        config = SmegConfig.builder()
+                .pncDefaultAlignmentParameters(
+                        CommonManipulatorConfigUtils.transformPncDefaultAlignmentParametersIntoList(adjustRequest))
+                .userSpecifiedAlignmentParameters(userSpecifiedAlignmentParameters.getAlignmentParameters())
+                .restMode(CommonManipulatorConfigUtils.computeRestMode(adjustRequest, adjustConfig))
+                .prefixOfVersionSuffix(
+                        CommonManipulatorConfigUtils.computePrefixOfVersionSuffix(adjustRequest, adjustConfig))
+                .alignmentConfigParameters(sbtProviderConfig.alignmentParameters())
+                .workdir(workdir.resolve(userSpecifiedAlignmentParameters.getSubFolder()))
+                .sbtPath(sbtProviderConfig.sbtPath())
+                .build();
+
+        log.debug("Successfully initialized, SMEG config: {}", config);
+    }
+
+    @Override
+    public void validateConfig() {
+        InvalidConfigUtils.validateResourceAtPathExists(
+                config.getSbtPath(),
+                "Scala build tool (specified at '%s') does not exist");
+    }
+
+    @Override
+    public List<String> prepareCommand() {
+
+        return AdjustmentSystemPropertiesUtils.joinSystemPropertiesListsIntoList(
+                List.of(
+                        List.of(config.getSbtPath().toString()),
+                        config.getPncDefaultAlignmentParameters(),
+                        config.getUserSpecifiedAlignmentParameters(),
+                        config.getAlignmentConfigParameters(),
+                        getComputedAlignmentParameters(),
+                        List.of("manipulate", "writeReport")));
+    }
+
+    private List<String> getComputedAlignmentParameters() {
+        final List<String> alignmentParameters = new ArrayList<>();
+
+        alignmentParameters
+                .add(AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(REST_MODE, config.getRestMode()));
+        alignmentParameters.add(
+                AdjustmentSystemPropertiesUtils
+                        .createAdjustmentSystemProperty(BREW_PULL_ACTIVE, config.isBrewPullEnabled()));
+        if (!config.getPrefixOfVersionSuffix().isBlank()) {
+            alignmentParameters.add(
+                    AdjustmentSystemPropertiesUtils.createAdjustmentSystemProperty(
+                            VERSION_INCREMENTAL_SUFFIX,
+                            config.getPrefixOfVersionSuffix() + "-redhat"));
+        }
+
+        return alignmentParameters;
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/utils/AdjustmentSystemPropertiesUtils.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/utils/AdjustmentSystemPropertiesUtils.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class AdjustmentSystemPropertiesUtils {
+
+    public static String createAdjustmentSystemProperty(AdjustmentSystemPropertyName name, Object value) {
+        return String.format("%s=%s", name.getCliRepresentation(), value);
+    }
+
+    public static Optional<String> getSystemPropertyValue(AdjustmentSystemPropertyName name, Stream<String> streams) {
+        return streams.filter(p -> p.startsWith(name.getCliRepresentation())).findFirst().map(p -> p.split("=")[1]);
+    }
+
+    public static Stream<String> joinSystemPropertiesListsIntoStream(List<List<String>> lists) {
+        return lists.stream().flatMap(Collection::stream);
+    }
+
+    public static List<String> joinSystemPropertiesListsIntoList(List<List<String>> lists) {
+        return joinSystemPropertiesListsIntoStream(lists).toList();
+    }
+
+    public enum AdjustmentSystemPropertyName {
+
+        REST_MODE("restMode"),
+        VERSION_INCREMENTAL_SUFFIX("versionIncrementalSuffix"),
+        BREW_PULL_ACTIVE("restBrewPullActive"),
+        VERSION_SUFFIX_ALTERNATIVES("versionSuffixAlternatives");
+
+        private final String cliName;
+
+        private AdjustmentSystemPropertyName(String cliName) {
+            this.cliName = cliName;
+        }
+
+        private String getCliRepresentation() {
+            return String.format("-D%s", cliName);
+        }
+    }
+}

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/utils/InvalidConfigUtils.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/utils/InvalidConfigUtils.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.utils;
+
+import org.jboss.pnc.reqour.adjust.exception.InvalidConfigException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class InvalidConfigUtils {
+
+    public static void validateResourceAtPathExists(Path path, String errorMessageTemplate) {
+        if (!Files.exists(path)) {
+            throw new InvalidConfigException(String.format(errorMessageTemplate, path));
+        }
+    }
+}

--- a/adjuster/src/main/resources/application-test.yaml
+++ b/adjuster/src/main/resources/application-test.yaml
@@ -1,0 +1,38 @@
+reqour-adjuster:
+  input-location: /opt/app/input-request.json
+  adjust:
+    mvn:
+      cli-jar-path: '${test.location.providers.mvn}/pom-manipulation-cli.jar'
+      default-settings-file-path: '${test.location.providers.mvn}/settings.xml'
+      temporary-settings-file-path: '${test.location.providers.mvn}/temporary-settings.xml'
+      alignment-parameters:
+        - '-DconfigAlignmentParam=foo'
+        - '-DrestURL=https://da.com/rest/v-1'
+        - '-DversionIncrementalSuffix=redhat'
+        - '-Doverride=config'
+    gradle:
+      gradle-analyzer-plugin-init-file-path: '${test.location.providers.gradle}/analyzer-init.gradle'
+      cli-jar-path: '${test.location.providers.gradle}/gme-cli.jar'
+      default-gradle-path: '${test.location.providers.gradle}/gradle-5.5.1'
+      alignment-parameters:
+        - '-Doverride=config'
+    scala:
+      sbt-path: '${test.location.providers.sbt}/sbt'
+      alignment-parameters:
+        - '-Doverride=config'
+    npm:
+      cli-jar-path: '${test.location.providers.npm}/project-manipulator-cli.jar'
+      alignment-parameters:
+        - '-Doverride=config'
+
+test:
+  location:
+    test-resources: 'src/test/resources'
+    requests:
+      dir: '${test.location.test-resources}/requests'
+    providers:
+      dir: '${test.location.test-resources}/providers'
+      mvn: '${test.location.providers.dir}/mvn'
+      gradle: '${test.location.providers.dir}/gradle'
+      sbt: '${test.location.providers.dir}/sbt'
+      npm: '${test.location.providers.dir}/npm'

--- a/adjuster/src/main/resources/application.yaml
+++ b/adjuster/src/main/resources/application.yaml
@@ -1,0 +1,12 @@
+reqour-adjuster:
+  adjust:
+    build-categories:
+      STANDARD:
+        persistent-mode: PERSISTENT
+        temporary-mode: TEMPORARY
+        temporary-prefer-persistent-mode: TEMPORARY_PREFER_PERSISTENT
+      SERVICE:
+        persistent-mode: SERVICE
+        temporary-mode: SERVICE_TEMPORARY
+        temporary-prefer-persistent-mode: SERVICE_TEMPORARY_PREFER_PERSISTENT
+        prefix-of-suffix-version: managedsvc

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/GradleAdjustProfile.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/GradleAdjustProfile.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.profiles;
+
+import org.jboss.pnc.reqour.common.profile.CommonTestProfile;
+
+import java.util.Set;
+
+public class GradleAdjustProfile extends CommonTestProfile {
+
+    @Override
+    public Set<String> tags() {
+        return Set.of(TestTag.GRADLE.name(), TestTag.ADJUST.name());
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/MvnAdjustProfile.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/MvnAdjustProfile.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.profiles;
+
+import org.jboss.pnc.reqour.common.profile.CommonTestProfile;
+
+import java.util.Set;
+
+public class MvnAdjustProfile extends CommonTestProfile {
+
+    @Override
+    public Set<String> tags() {
+        return Set.of(TestTag.MVN.name(), TestTag.ADJUST.name());
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/NpmAdjustProfile.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/NpmAdjustProfile.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.profiles;
+
+import org.jboss.pnc.reqour.common.profile.CommonTestProfile;
+
+import java.util.Set;
+
+public class NpmAdjustProfile extends CommonTestProfile {
+
+    @Override
+    public Set<String> tags() {
+        return Set.of(TestTag.NPM.name(), TestTag.ADJUST.name());
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/SbtAdjustProfile.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profiles/SbtAdjustProfile.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.profiles;
+
+import org.jboss.pnc.reqour.common.profile.CommonTestProfile;
+
+import java.util.Set;
+
+public class SbtAdjustProfile extends CommonTestProfile {
+
+    @Override
+    public Set<String> tags() {
+        return Set.of(TestTag.SBT.name(), TestTag.ADJUST.name());
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/GradleProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/GradleProviderTest.java
@@ -5,9 +5,11 @@
 package org.jboss.pnc.reqour.adjust.provider;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.assertj.core.data.MapEntry;
 import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.adjust.profiles.GradleAdjustProfile;
 import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,6 +25,7 @@ import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropert
 import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
 
 @QuarkusTest
+@TestProfile(GradleAdjustProfile.class)
 class GradleProviderTest {
 
     @Inject

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/GradleProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/GradleProviderTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.assertj.core.data.MapEntry;
+import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertiesContainExactly;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
+
+@QuarkusTest
+class GradleProviderTest {
+
+    @Inject
+    ReqourAdjusterConfig config;
+
+    @Inject
+    TestUtils testUtils;
+
+    static Path workdir;
+
+    @BeforeAll
+    static void beforeAll() {
+        workdir = IOUtils.createTempDirForAdjust();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        IOUtils.deleteTempDir(workdir);
+    }
+
+    @Test
+    void prepareCommand_standardPersistentBuildWithPersistentPreference_generatedCommandIsCorrect() {
+        GradleProvider provider = new GradleProvider(
+                config.adjust(),
+                testUtils.getAdjustRequest(Path.of("gradle-request.json")),
+                workdir);
+
+        List<String> command = provider.preparedCommand;
+
+        assertThat(command).containsSequence(
+                List.of(
+                        "java",
+                        "-jar",
+                        config.adjust().gradleProviderConfig().cliJarPath().toString(),
+                        "--target",
+                        workdir.toString(),
+                        "--init-script",
+                        config.adjust().gradleProviderConfig().gradleAnalyzerPluginInitFilePath().toString(),
+                        "-l",
+                        config.adjust().gradleProviderConfig().defaultGradlePath().toString()));
+        assertSystemPropertiesContainExactly(
+                command,
+                Map.ofEntries(
+                        MapEntry.entry("override", 3),
+                        MapEntry.entry("restMode", 1),
+                        MapEntry.entry("restBrewPullActive", 1)));
+        assertSystemPropertyHasValuesSortedByPriority(command, "override", List.of("default", "user", "config"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restMode", List.of("PERSISTENT"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restBrewPullActive", List.of("false"));
+    }
+
+    @Test
+    void prepareCommand_servicePersistentBuildWithTemporaryPreference_generatedCommandIsCorrect() {
+        GradleProvider provider = new GradleProvider(
+                config.adjust(),
+                testUtils.getAdjustRequest(Path.of("gradle-request-2.json")),
+                workdir);
+
+        List<String> command = provider.preparedCommand;
+
+        assertThat(command).containsSequence(
+                List.of(
+                        "java",
+                        "-jar",
+                        config.adjust().gradleProviderConfig().cliJarPath().toString(),
+                        "--target",
+                        workdir.toString(),
+                        "--init-script",
+                        config.adjust().gradleProviderConfig().gradleAnalyzerPluginInitFilePath().toString(),
+                        "-l",
+                        config.adjust().gradleProviderConfig().defaultGradlePath().toString()));
+        assertSystemPropertiesContainExactly(
+                command,
+                Map.ofEntries(
+                        MapEntry.entry("override", 3),
+                        MapEntry.entry("restMode", 1),
+                        MapEntry.entry("restBrewPullActive", 1),
+                        MapEntry.entry("versionIncrementalSuffix", 2)));
+        assertSystemPropertyHasValuesSortedByPriority(command, "override", List.of("default", "user", "config"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restMode", List.of("SERVICE"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restBrewPullActive", List.of("true"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "versionIncrementalSuffix",
+                List.of("user", "managedsvc-redhat"));
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/MvnProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/MvnProviderTest.java
@@ -5,9 +5,12 @@
 package org.jboss.pnc.reqour.adjust.provider;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.assertj.core.data.MapEntry;
 import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.adjust.profiles.GradleAdjustProfile;
+import org.jboss.pnc.reqour.adjust.profiles.MvnAdjustProfile;
 import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,6 +26,7 @@ import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropert
 import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
 
 @QuarkusTest
+@TestProfile(MvnAdjustProfile.class)
 public class MvnProviderTest {
 
     @Inject

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/MvnProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/MvnProviderTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.assertj.core.data.MapEntry;
+import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertiesContainExactly;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
+
+@QuarkusTest
+public class MvnProviderTest {
+
+    @Inject
+    ReqourAdjusterConfig config;
+
+    @Inject
+    TestUtils testUtils;
+
+    static Path workdir;
+
+    @BeforeAll
+    static void beforeAll() {
+        workdir = IOUtils.createTempDirForAdjust();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        IOUtils.deleteTempDir(workdir);
+    }
+
+    @Test
+    void prepareCommand_servicePersistentBuildWithPersistentPreference_generatedCommandIsCorrect() {
+        MvnProvider provider = new MvnProvider(
+                config.adjust(),
+                testUtils.getAdjustRequest(Path.of("mvn-request.json")),
+                workdir);
+
+        List<String> command = provider.preparedCommand;
+
+        assertThat(command).containsSequence(
+                List.of(
+                        "java",
+                        "-jar",
+                        config.adjust().mvnProviderConfig().cliJarPath().toString(),
+                        "-s",
+                        config.adjust().mvnProviderConfig().defaultSettingsFilePath().toString()));
+        assertSystemPropertiesContainExactly(
+                command,
+                Map.ofEntries(
+                        MapEntry.entry("override", 3),
+                        MapEntry.entry("configAlignmentParam", 1),
+                        MapEntry.entry("restURL", 1),
+                        MapEntry.entry("restMode", 1),
+                        MapEntry.entry("versionIncrementalSuffix", 2),
+                        MapEntry.entry("versionSuffixAlternatives", 1),
+                        MapEntry.entry("restBrewPullActive", 1)));
+        assertSystemPropertyHasValuesSortedByPriority(command, "override", List.of("default", "user", "config"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "configAlignmentParam", List.of("foo"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restURL", List.of("https://da.com/rest/v-1"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restMode", List.of("SERVICE"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "versionIncrementalSuffix",
+                List.of("redhat", "managedsvc-redhat"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "versionSuffixAlternatives",
+                List.of("redhat,managedsvc-redhat"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restBrewPullActive", List.of("true"));
+    }
+
+    @Test
+    void prepareCommand_standardTemporaryBuildWithTemporaryPreference_generatedCommandIsCorrect() {
+        MvnProvider provider = new MvnProvider(
+                config.adjust(),
+                testUtils.getAdjustRequest(Path.of("mvn-request-2.json")),
+                workdir);
+
+        List<String> command = provider.preparedCommand;
+
+        assertThat(command).containsSequence(
+                List.of(
+                        "java",
+                        "-jar",
+                        config.adjust().mvnProviderConfig().cliJarPath().toString(),
+                        "-s",
+                        config.adjust().mvnProviderConfig().temporarySettingsFilePath().toString()));
+        assertSystemPropertiesContainExactly(
+                command,
+                Map.ofEntries(
+                        MapEntry.entry("override", 3),
+                        MapEntry.entry("defaultAlignmentParam", 1),
+                        MapEntry.entry("sameKeyInDefaultAndUserParams", 2),
+                        MapEntry.entry("userSpecifiedAlignmentParam", 1),
+                        MapEntry.entry("configAlignmentParam", 1),
+                        MapEntry.entry("restURL", 2),
+                        MapEntry.entry("restMode", 1),
+                        MapEntry.entry("versionIncrementalSuffix", 2),
+                        MapEntry.entry("restBrewPullActive", 1)));
+        assertSystemPropertyHasValuesSortedByPriority(command, "defaultAlignmentParam", List.of("foo"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "sameKeyInDefaultAndUserParams",
+                List.of("default", "user"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "override", List.of("default", "user", "config"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "userSpecifiedAlignmentParam", List.of("foo"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "configAlignmentParam", List.of("foo"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "restURL",
+                List.of("https://user-specified.com/da/v1", "https://da.com/rest/v-1"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restMode", List.of("TEMPORARY"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "versionIncrementalSuffix",
+                List.of("redhat", "temporary-redhat"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restBrewPullActive", List.of("false"));
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/NpmProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/NpmProviderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.assertj.core.data.MapEntry;
+import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertiesContainExactly;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
+
+@QuarkusTest
+class NpmProviderTest {
+
+    @Inject
+    ReqourAdjusterConfig config;
+
+    @Inject
+    TestUtils testUtils;
+
+    static Path workdir;
+
+    @BeforeAll
+    static void beforeAll() {
+        workdir = IOUtils.createTempDirForAdjust();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        IOUtils.deleteTempDir(workdir);
+    }
+
+    @Test
+    void prepareCommand_standardTemporaryBuildWithPersistentPreference_generatedCommandIsCorrect() {
+        NpmProvider provider = new NpmProvider(
+                config.adjust(),
+                testUtils.getAdjustRequest(Path.of("npm-request.json")),
+                workdir);
+
+        List<String> command = provider.preparedCommand;
+
+        assertThat(command)
+                .containsSequence(List.of("java", "-jar", config.adjust().npmProviderConfig().cliJarPath().toString()));
+        assertSystemPropertiesContainExactly(
+                command,
+                Map.ofEntries(
+                        MapEntry.entry("override", 3),
+                        MapEntry.entry("restMode", 1),
+                        MapEntry.entry("versionIncrementalSuffix", 3)));
+        assertSystemPropertyHasValuesSortedByPriority(command, "override", List.of("default", "user", "config"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restMode", List.of("TEMPORARY_PREFER_PERSISTENT"));
+        assertSystemPropertyHasValuesSortedByPriority(
+                command,
+                "versionIncrementalSuffix",
+                List.of("default", "user", "temporary-user"));
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/NpmProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/NpmProviderTest.java
@@ -5,9 +5,12 @@
 package org.jboss.pnc.reqour.adjust.provider;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.assertj.core.data.MapEntry;
 import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.adjust.profiles.MvnAdjustProfile;
+import org.jboss.pnc.reqour.adjust.profiles.NpmAdjustProfile;
 import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,6 +26,7 @@ import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropert
 import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
 
 @QuarkusTest
+@TestProfile(NpmAdjustProfile.class)
 class NpmProviderTest {
 
     @Inject

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/SbtProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/SbtProviderTest.java
@@ -5,9 +5,12 @@
 package org.jboss.pnc.reqour.adjust.provider;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.assertj.core.data.MapEntry;
 import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.adjust.profiles.NpmAdjustProfile;
+import org.jboss.pnc.reqour.adjust.profiles.SbtAdjustProfile;
 import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,6 +26,7 @@ import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropert
 import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
 
 @QuarkusTest
+@TestProfile(SbtAdjustProfile.class)
 class SbtProviderTest {
 
     @Inject

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/SbtProviderTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/SbtProviderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.assertj.core.data.MapEntry;
+import org.jboss.pnc.reqour.adjust.config.ReqourAdjusterConfig;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertiesContainExactly;
+import static org.jboss.pnc.reqour.adjust.provider.TestUtils.assertSystemPropertyHasValuesSortedByPriority;
+
+@QuarkusTest
+class SbtProviderTest {
+
+    @Inject
+    ReqourAdjusterConfig config;
+
+    @Inject
+    TestUtils testUtils;
+
+    static Path workdir;
+
+    @BeforeAll
+    static void beforeAll() {
+        workdir = IOUtils.createTempDirForAdjust();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        IOUtils.deleteTempDir(workdir);
+    }
+
+    @Test
+    void prepareCommand_standardTemporaryBuildWithPersistentAlignmentPreference_generatedCommandIsCorrect() {
+        SbtProvider provider = new SbtProvider(
+                config.adjust(),
+                testUtils.getAdjustRequest(Path.of("sbt-request.json")),
+                workdir);
+
+        List<String> command = provider.preparedCommand;
+
+        assertThat(command).containsSequence(List.of(config.adjust().scalaProviderConfig().sbtPath().toString()));
+        assertSystemPropertiesContainExactly(
+                command,
+                Map.ofEntries(
+                        MapEntry.entry("override", 3),
+                        MapEntry.entry("restMode", 1),
+                        MapEntry.entry("versionIncrementalSuffix", 1),
+                        MapEntry.entry("restBrewPullActive", 1)));
+        assertSystemPropertyHasValuesSortedByPriority(command, "override", List.of("default", "user", "config"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restMode", List.of("TEMPORARY_PREFER_PERSISTENT"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "versionIncrementalSuffix", List.of("temporary-redhat"));
+        assertSystemPropertyHasValuesSortedByPriority(command, "restBrewPullActive", List.of("false"));
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/TestUtils.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/provider/TestUtils.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ApplicationScoped
+public class TestUtils {
+
+    @ConfigProperty(name = "test.location.requests.dir")
+    Path requestsLocation;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    public AdjustRequest getAdjustRequest(Path requestInputFile) {
+        try {
+            return objectMapper.readValue(requestsLocation.resolve(requestInputFile).toFile(), AdjustRequest.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * TODO
+     */
+    public static void assertSystemPropertyHasValuesSortedByPriority(
+            List<String> command,
+            String systemProperty,
+            List<String> expectedValues) {
+        List<String> actualValues = command.stream()
+                .filter(p -> p.startsWith(String.format("-D%s=", systemProperty)))
+                .map(p -> p.split("=")[1])
+                .toList();
+
+        assertThat(actualValues).isEqualTo(expectedValues);
+    }
+
+    public static void assertSystemPropertiesContainExactly(
+            List<String> command,
+            Map<String, Integer> expectedSystemPropertiesCounts) {
+        Map<String, Integer> actualSystemPropertiesCount = new HashMap<>();
+
+        command.stream().filter(p -> p.startsWith("-D")).map(p -> p.replace("-D", "")).forEach(s -> {
+            String systemPropertyName = s.split("=")[0];
+            actualSystemPropertiesCount
+                    .put(systemPropertyName, actualSystemPropertiesCount.getOrDefault(systemPropertyName, 0) + 1);
+        });
+
+        assertThat(actualSystemPropertiesCount).isEqualTo(expectedSystemPropertiesCounts);
+    }
+}

--- a/adjuster/src/test/resources/providers/gradle/analyzer-init.gradle
+++ b/adjuster/src/test/resources/providers/gradle/analyzer-init.gradle
@@ -1,0 +1,1 @@
+// GradleProvider is checking whether this file exists

--- a/adjuster/src/test/resources/providers/gradle/gradle-5.5.1
+++ b/adjuster/src/test/resources/providers/gradle/gradle-5.5.1
@@ -1,0 +1,1 @@
+# GradleProvider is checking whether this file exists

--- a/adjuster/src/test/resources/providers/mvn/settings.xml
+++ b/adjuster/src/test/resources/providers/mvn/settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <!-- MvnProvider is validating whether this file exists -->
+</config>

--- a/adjuster/src/test/resources/providers/mvn/temporary-settings.xml
+++ b/adjuster/src/test/resources/providers/mvn/temporary-settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <!-- MvnProvider is validating whether this file exists -->
+</config>

--- a/adjuster/src/test/resources/providers/sbt/sbt
+++ b/adjuster/src/test/resources/providers/sbt/sbt
@@ -1,0 +1,1 @@
+# SbtProvider is checking whether this file exists

--- a/adjuster/src/test/resources/requests/gradle-request-2.json
+++ b/adjuster/src/test/resources/requests/gradle-request-2.json
@@ -1,0 +1,23 @@
+{
+  "ref": "master",
+  "callback": {
+    "method": "POST",
+    "uri": "https://example.com/callback"
+  },
+  "sync": true,
+  "originRepoUrl": "https://github.com/project/repo",
+  "buildConfigParameters": {
+    "ALIGNMENT_PARAMETERS": "-Doverride=user -DversionIncrementalSuffix=user",
+    "BUILD_CATEGORY": "SERVICE"
+  },
+  "tempBuild": false,
+  "alignmentPreference": "PREFER_TEMPORARY",
+  "taskId": "task-id",
+  "buildType": "GRADLE",
+  "pncDefaultAlignmentParameters": "-Doverride=default",
+  "brewPullActive": true,
+  "internalUrl": {
+    "readwriteUrl": "git@gitlab.com:test-workspace/repo/project.git",
+    "readonlyUrl": "https://gitlab.com/test-workspace/repo/project.git"
+  }
+}

--- a/adjuster/src/test/resources/requests/gradle-request.json
+++ b/adjuster/src/test/resources/requests/gradle-request.json
@@ -1,0 +1,22 @@
+{
+  "ref": "master",
+  "callback": {
+    "method": "POST",
+    "uri": "https://example.com/callback"
+  },
+  "sync": true,
+  "originRepoUrl": "https://github.com/project/repo",
+  "buildConfigParameters": {
+    "ALIGNMENT_PARAMETERS": "-Doverride=user"
+  },
+  "tempBuild": false,
+  "alignmentPreference": "PREFER_PERSISTENT",
+  "taskId": "task-id",
+  "buildType": "GRADLE",
+  "pncDefaultAlignmentParameters": "-Doverride=default",
+  "brewPullActive": false,
+  "internalUrl": {
+    "readwriteUrl": "git@gitlab.com:test-workspace/repo/project.git",
+    "readonlyUrl": "https://gitlab.com/test-workspace/repo/project.git"
+  }
+}

--- a/adjuster/src/test/resources/requests/mvn-request-2.json
+++ b/adjuster/src/test/resources/requests/mvn-request-2.json
@@ -1,0 +1,22 @@
+{
+  "ref": "main",
+  "callback": {
+    "method": "POST",
+    "uri": "https://example.com/callback"
+  },
+  "sync": true,
+  "originRepoUrl": "git@gitlab.com:repo/project.git",
+  "buildConfigParameters": {
+    "ALIGNMENT_PARAMETERS": "-DuserSpecifiedAlignmentParam=foo -DsameKeyInDefaultAndUserParams=user -DrestURL=https://user-specified.com/da/v1 -Doverride=user"
+  },
+  "tempBuild": true,
+  "alignmentPreference": "PREFER_TEMPORARY",
+  "taskId": "task-id",
+  "buildType": "MVN",
+  "pncDefaultAlignmentParameters": "-DdefaultAlignmentParam=foo -DsameKeyInDefaultAndUserParams=default -Doverride=default",
+  "brewPullActive": false,
+  "internalUrl": {
+    "readwriteUrl": "git@gitlab.com:test-workspace/repo/project.git",
+    "readonlyUrl": "https://gitlab.com/test-workspace/repo/project.git"
+  }
+}

--- a/adjuster/src/test/resources/requests/mvn-request.json
+++ b/adjuster/src/test/resources/requests/mvn-request.json
@@ -1,0 +1,23 @@
+{
+  "ref": "main",
+  "callback": {
+    "method": "POST",
+    "uri": "https://example.com/callback"
+  },
+  "sync": true,
+  "originRepoUrl": "git@gitlab.com:repo/project.git",
+  "buildConfigParameters": {
+    "ALIGNMENT_PARAMETERS": "-Doverride=user",
+    "BUILD_CATEGORY": "SERVICE"
+  },
+  "tempBuild": false,
+  "alignmentPreference": "PREFER_PERSISTENT",
+  "taskId": "task-id",
+  "buildType": "MVN",
+  "pncDefaultAlignmentParameters": "-Doverride=default",
+  "brewPullActive": true,
+  "internalUrl": {
+    "readwriteUrl": "git@gitlab.com:test-workspace/repo/project.git",
+    "readonlyUrl": "https://gitlab.com/test-workspace/repo/project.git"
+  }
+}

--- a/adjuster/src/test/resources/requests/npm-request.json
+++ b/adjuster/src/test/resources/requests/npm-request.json
@@ -1,0 +1,22 @@
+{
+  "ref": "main",
+  "callback": {
+    "method": "POST",
+    "uri": "https://example.com/callback"
+  },
+  "sync": true,
+  "originRepoUrl": "https://github.com/project/repo",
+  "buildConfigParameters": {
+    "ALIGNMENT_PARAMETERS": "-Doverride=user -DversionIncrementalSuffix=user"
+  },
+  "tempBuild": true,
+  "alignmentPreference": "PREFER_PERSISTENT",
+  "taskId": "task-id",
+  "buildType": "NPM",
+  "pncDefaultAlignmentParameters": "-Doverride=default -DversionIncrementalSuffix=default",
+  "brewPullActive": true,
+  "internalUrl": {
+    "readwriteUrl": "git@gitlab.com:test-workspace/repo/project.git",
+    "readonlyUrl": "https://gitlab.com/test-workspace/repo/project.git"
+  }
+}

--- a/adjuster/src/test/resources/requests/sbt-request.json
+++ b/adjuster/src/test/resources/requests/sbt-request.json
@@ -1,0 +1,22 @@
+{
+  "ref": "v42.42.42",
+  "callback": {
+    "method": "POST",
+    "uri": "https://example.com/callback"
+  },
+  "sync": false,
+  "originRepoUrl": "https://github.com/repo/project",
+  "buildConfigParameters": {
+    "ALIGNMENT_PARAMETERS": "-Doverride=user"
+  },
+  "tempBuild": true,
+  "alignmentPreference": "PREFER_PERSISTENT",
+  "taskId": "task-id",
+  "buildType": "SBT",
+  "pncDefaultAlignmentParameters": "-Doverride=default",
+  "brewPullActive": false,
+  "internalUrl": {
+    "readwriteUrl": "git@gitlab.com:test-workspace/repo/project.git",
+    "readonlyUrl": "https://gitlab.com/test-workspace/repo/project.git"
+  }
+}

--- a/core/src/main/java/org/jboss/pnc/reqour/common/utils/IOUtils.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/common/utils/IOUtils.java
@@ -17,10 +17,18 @@ public class IOUtils {
     }
 
     public static Path createTempDirForCloning() {
+        return createTempDir("clone-", "cloning");
+    }
+
+    public static Path createTempDirForAdjust() {
+        return createTempDir("adjust-", "adjust");
+    }
+
+    private static Path createTempDir(String prefix, String activity) {
         try {
-            return Files.createTempDirectory("clone-");
+            return Files.createTempDirectory(prefix);
         } catch (IOException e) {
-            throw new RuntimeException("Cannot create temporary directory for cloning", e);
+            throw new RuntimeException("Cannot create temporary directory for " + activity, e);
         }
     }
 

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/CloningProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/CloningProfile.java
@@ -10,6 +10,6 @@ public class CloningProfile extends CommonTestProfile {
 
     @Override
     public Set<String> tags() {
-        return Set.of("cloning");
+        return Set.of(TestTag.CLONING.name());
     }
 }

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/CommonTestProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/CommonTestProfile.java
@@ -16,4 +16,8 @@ public abstract class CommonTestProfile implements QuarkusTestProfile {
     public String getConfigProfile() {
         return "test";
     }
+
+    protected enum TestTag {
+        ADJUST, CLONING, CONFIG, GRADLE, INTERNAL_SCM_CREATION, MVN, NPM, SBT, TRANSLATION, UTILS, VERSION,
+    }
 }

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/ConfigProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/ConfigProfile.java
@@ -10,6 +10,6 @@ public class ConfigProfile extends CommonTestProfile {
 
     @Override
     public Set<String> tags() {
-        return Set.of("config");
+        return Set.of(TestTag.CONFIG.name());
     }
 }

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/InternalSCMRepositoryCreationProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/InternalSCMRepositoryCreationProfile.java
@@ -10,6 +10,6 @@ public class InternalSCMRepositoryCreationProfile extends CommonTestProfile {
 
     @Override
     public Set<String> tags() {
-        return Set.of("internal-scm-creation");
+        return Set.of(TestTag.INTERNAL_SCM_CREATION.name());
     }
 }

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/TranslationProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/TranslationProfile.java
@@ -10,6 +10,6 @@ public class TranslationProfile extends CommonTestProfile {
 
     @Override
     public Set<String> tags() {
-        return Set.of("translation");
+        return Set.of(TestTag.TRANSLATION.name());
     }
 }

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/UtilsProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/UtilsProfile.java
@@ -10,6 +10,6 @@ public class UtilsProfile extends CommonTestProfile {
 
     @Override
     public Set<String> tags() {
-        return Set.of("utils");
+        return Set.of(TestTag.UTILS.name());
     }
 }

--- a/core/src/test/java/org/jboss/pnc/reqour/common/profile/VersionProfile.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/profile/VersionProfile.java
@@ -10,6 +10,6 @@ public class VersionProfile extends CommonTestProfile {
 
     @Override
     public Set<String> tags() {
-        return Set.of("version");
+        return Set.of(TestTag.VERSION.name());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>adjuster</module>
         <module>core</module>
         <module>rest</module>
     </modules>
@@ -175,6 +176,7 @@
                             <exclude>**/**.properties</exclude>
                             <exclude>**/application*.yaml</exclude>
                             <exclude>src/test/resources/clone-test/source-repo/*.txt</exclude>
+                            <exclude>src/test/resources/**/*</exclude>
 
                             <!-- Exclude downloaded/generated -->
                             <exclude>**/.cache/**</exclude>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -67,6 +67,12 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.jboss.pnc.reqour</groupId>
+            <artifactId>reqour-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
@@ -94,12 +100,6 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.pnc.reqour</groupId>
-            <artifactId>reqour-core</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- The whole adjust operation is not done at all -- there is still significant part missing, namely, creation of the pod at openshift per every build
- However, `reqour-adjuster` module is the jar which will run inside the container and it will actually delegate the work to one of its 4 manipulators (based on build type, e.g. 'MVN')
- As the next step, it's needed to create `Containerfile`, which will contain this jar and all the necessary tools in it, e.g. gradle or certificates
- **Please note:** because of the above, there are some parts, which are not still fully finished