### PR TITLE
Add '^{commit}' to doesShaExist

### DIFF
--- a/core/src/main/java/org/jboss/pnc/reqour/common/utils/GitUtils.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/common/utils/GitUtils.java
@@ -90,7 +90,7 @@ public class GitUtils {
     }
 
     public static List<String> doesShaExists(String ref) {
-        return List.of("git", "cat-file", "-e", ref);
+        return List.of("git", "cat-file", "-e", ref + "^{commit}");
     }
 
     public static List<String> fetchRef(String remote, String ref, boolean fetchShallowly, boolean dryRun) {


### PR DESCRIPTION
Add '^{commit}' to the:
```
$ git cat-file -e <ref>^{commit}
```

command to specify that we want to see if the <ref> is a commit SHA.