### PR TITLE
[NCL-8996]: Make check for existence of ref during alignment in remot…

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/AdjustmentPusher.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/AdjustmentPusher.java
@@ -109,12 +109,12 @@ public class AdjustmentPusher {
         String commitId = gitCommands.revParse(workdir);
 
         String tagName = (alignmentRootVersion != null) ? alignmentRootVersion : String.format("reqour-%s", commitId);
-        boolean doesTagAlreadyExist = gitCommands.isReferenceTag(tagName, processContextBuilder);
+        boolean doesTagAlreadyExist = gitCommands.doesTagExistLocally(tagName, processContextBuilder);
         if (doesTagAlreadyExist) {
             tagName = String.format("%s-%s", tagName, commitId.substring(0, 8));
         }
 
-        if (gitCommands.isReferenceTag(tagName, processContextBuilder)) {
+        if (gitCommands.doesTagExistLocally(tagName, processContextBuilder)) {
             return tagName;
         }
 

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RepositoryFetcher.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RepositoryFetcher.java
@@ -114,7 +114,7 @@ public class RepositoryFetcher {
         ProcessContext.Builder processContextBuilder = ProcessContext.defaultBuilderWithWorkdir(workdir);
         gitCommands.clone(adjustRequest.getOriginRepoUrl(), processContextBuilder);
 
-        if (gitCommands.doesReferenceExist(adjustRequest.getRef(), processContextBuilder)) {
+        if (gitCommands.doesReferenceExistRemotely(adjustRequest.getRef(), processContextBuilder)) {
             boolean isRefPR = GitCommands.isReferencePR(adjustRequest.getRef());
             if (isRefPR) {
                 gitCommands.checkoutPR(adjustRequest.getRef(), processContextBuilder);
@@ -151,7 +151,7 @@ public class RepositoryFetcher {
             gitCommands.clone(
                     URLUtils.addUsernameToUrl(adjustRequest.getInternalUrl().getReadwriteUrl(), gitUsername),
                     processContextBuilder);
-            if (gitCommands.doesReferenceExist(adjustRequest.getRef(), processContextBuilder)) {
+            if (gitCommands.doesReferenceExistRemotely(adjustRequest.getRef(), processContextBuilder)) {
                 log.debug("Downstream repository has the ref, but not the upstream one. No syncing required!");
                 gitCommands.checkout(adjustRequest.getRef(), true, processContextBuilder);
                 isRefInternal = true;

--- a/core/src/main/java/org/jboss/pnc/reqour/common/GitCommands.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/common/GitCommands.java
@@ -159,12 +159,18 @@ public class GitCommands {
                 .execute(processContextBuilder.command(GitUtils.doesBranchExistAtRemote(remote, branch)).build()) == 0;
     }
 
-    public boolean isReferenceBranch(String ref, ProcessContext.Builder processContextBuilder) {
-        return processExecutor.execute(processContextBuilder.command(GitUtils.isReferenceBranch(ref)).build()) == 0;
+    public boolean doesBranchExistsLocally(String ref, ProcessContext.Builder processContextBuilder) {
+        return processExecutor
+                .execute(processContextBuilder.command(GitUtils.doesBranchExistLocally(ref)).build()) == 0;
     }
 
-    public boolean isReferenceTag(String ref, ProcessContext.Builder processContextBuilder) {
-        return processExecutor.execute(processContextBuilder.command(GitUtils.isReferenceTag(ref)).build()) == 0;
+    public boolean doesTagExistLocally(String ref, ProcessContext.Builder processContextBuilder) {
+        return processExecutor.execute(processContextBuilder.command(GitUtils.doesTagExistLocally(ref)).build()) == 0;
+    }
+
+    public boolean doesTagExistAtRemote(String remote, String ref, ProcessContext.Builder processContextBuilder) {
+        return processExecutor
+                .execute(processContextBuilder.command(GitUtils.doesTagExistAtRemote(remote, ref)).build()) == 0;
     }
 
     public boolean doesShaExists(String ref, ProcessContext.Builder processContextBuilder) {
@@ -186,19 +192,20 @@ public class GitCommands {
         checkout(GitUtils.FETCH_HEAD, false, processContextBuilder);
     }
 
-    public boolean doesReferenceExist(String ref, ProcessContext.Builder processContextBuilder) {
-        return isReferenceTag(ref, processContextBuilder) || isReferenceBranch(ref, processContextBuilder)
-                || doesShaExists(ref, processContextBuilder) || doesPRExists(ref, processContextBuilder);
+    public boolean doesReferenceExistRemotely(String ref, ProcessContext.Builder processContextBuilder) {
+        return doesReferenceExistAtRemote(DEFAULT_REMOTE_NAME, ref, processContextBuilder);
     }
 
-    public boolean doesPRExists(String ref, ProcessContext.Builder processContextBuilder) {
+    public boolean doesReferenceExistAtRemote(String remote, String ref, ProcessContext.Builder processContextBuilder) {
+        return doesTagExistAtRemote(remote, ref, processContextBuilder)
+                || doesBranchExistAtRemote(remote, ref, processContextBuilder)
+                || doesShaExists(ref, processContextBuilder)
+                || doesPRExistsAtRemote(remote, ref, processContextBuilder);
+    }
+
+    public boolean doesPRExistsAtRemote(String remote, String ref, ProcessContext.Builder processContextBuilder) {
         try {
-            fetchRef(
-                    GitUtils.DEFAULT_REMOTE_NAME,
-                    modifyPullRequestRefToBeFetchable(ref),
-                    false,
-                    true,
-                    processContextBuilder);
+            fetchRef(remote, modifyPullRequestRefToBeFetchable(ref), false, true, processContextBuilder);
             return true;
         } catch (GitException _e) {
             return false;

--- a/core/src/main/java/org/jboss/pnc/reqour/common/utils/GitUtils.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/common/utils/GitUtils.java
@@ -77,16 +77,20 @@ public class GitUtils {
         return command;
     }
 
+    public static List<String> doesBranchExistLocally(String ref) {
+        return List.of("git", "show-ref", "-q", "--heads", ref);
+    }
+
     public static List<String> doesBranchExistAtRemote(String remote, String branch) {
         return List.of("git", "show-branch", String.format("remotes/%s/%s", remote, branch));
     }
 
-    public static List<String> isReferenceBranch(String ref) {
-        return List.of("git", "show-ref", "-q", "--heads", ref);
+    public static List<String> doesTagExistLocally(String ref) {
+        return List.of("git", "show-ref", "-q", "--tags", ref);
     }
 
-    public static List<String> isReferenceTag(String ref) {
-        return List.of("git", "show-ref", "-q", "--tags", ref);
+    public static List<String> doesTagExistAtRemote(String remote, String tag) {
+        return List.of("git", "ls-remote", remote, String.format("refs/tags/%s", tag));
     }
 
     public static List<String> doesShaExists(String ref) {

--- a/core/src/main/java/org/jboss/pnc/reqour/service/GitCloneService.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/service/GitCloneService.java
@@ -118,9 +118,9 @@ public class GitCloneService implements CloneService {
     }
 
     public void pushClonedChanges(String ref, String remote, ProcessContext.Builder processContextBuilder) {
-        if (gitCommands.isReferenceBranch(ref, processContextBuilder)) {
+        if (gitCommands.doesBranchExistsLocally(ref, processContextBuilder)) {
             gitCommands.push(remote, ref, false, processContextBuilder);
-        } else if (gitCommands.isReferenceTag(ref, processContextBuilder)) {
+        } else if (gitCommands.doesTagExistLocally(ref, processContextBuilder)) {
             gitCommands.pushTags(
                     remote,
                     gitCommands.listTagsReachableFromRef(ref, processContextBuilder),
@@ -134,7 +134,7 @@ public class GitCloneService implements CloneService {
         log.info("adding tag and pushing");
         String newTag = "reqour-sync-" + ref;
 
-        if (gitCommands.isReferenceTag(newTag, processContextBuilder)) {
+        if (gitCommands.doesTagExistLocally(newTag, processContextBuilder)) {
             throw new GitException(
                     String.format(
                             "Cannot create tag '%s' in the remote '%s'. This tag already exists.",


### PR DESCRIPTION
…e repo

Previously, the check took place in local repository, whcih was not correct since only cloning of the default branch happened beforehand. Because of that, ref, which pointed to somewhere else than a reference at the default branch, was simply not found.