### PR TITLE
[NCL-8971]: Reformat final logs

### DIFF
--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentFailureTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentFailureTest.java
@@ -52,7 +52,13 @@ public class AlignmentFailureTest {
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(BIFROST_FINAL_LOG_UPLOAD_PATH))
-                        .withRequestBody(WireMock.containing("Oops, alignment exception")));
+                        .withRequestBody(
+                                WireMock.and(
+                                        WireMock.containing("[INFO] Cloning a repository"),
+                                        WireMock.containing("[WARN] Exception was: org.jboss.pnc.reqour.adjust.exception.AdjusterException: Oops, alignment exception")
+                                )
+                        ));
+
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(CALLBACK_PATH))

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentSuccessTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentSuccessTest.java
@@ -59,10 +59,10 @@ class AlignmentSuccessTest {
                 WireMock.postRequestedFor(WireMock.urlEqualTo(BIFROST_FINAL_LOG_UPLOAD_PATH))
                         .withRequestBody(
                                 WireMock.and(
-                                        WireMock.containing("Cloning a repository"),
+                                        WireMock.containing("[INFO] Cloning a repository"),
                                         WireMock.containing(
-                                                "Starting an alignment process using the corresponding manipulator"),
-                                        WireMock.containing("Pushing aligned changes"))));
+                                                "[INFO] Starting an alignment process using the corresponding manipulator"),
+                                        WireMock.containing("[INFO] Pushing aligned changes"))));
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(CALLBACK_PATH))

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -97,6 +97,11 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20250107</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/core/src/main/java/org/jboss/pnc/reqour/common/utils/IOUtils.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/common/utils/IOUtils.java
@@ -67,4 +67,11 @@ public class IOUtils {
         int diff = c - 'A';
         return (char) ('a' + diff);
     }
+
+    /**
+     * Creates an {@link AutoCloseable} which automatically closes the file at the end of its lifecycle.
+     */
+    public static AutoCloseable createFileAutoCloseable(Path file) {
+        return () -> Files.deleteIfExists(file);
+    }
 }

--- a/core/src/main/java/org/jboss/pnc/reqour/runtime/BifrostLogUploaderWrapper.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/runtime/BifrostLogUploaderWrapper.java
@@ -12,10 +12,16 @@ import org.jboss.pnc.bifrost.upload.BifrostUploadException;
 import org.jboss.pnc.bifrost.upload.LogMetadata;
 import org.jboss.pnc.bifrost.upload.TagOption;
 import org.jboss.pnc.common.log.MDCUtils;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.jboss.pnc.reqour.config.ReqourConfig;
 import org.jboss.pnc.reqour.enums.FinalLogUploader;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +43,7 @@ public class BifrostLogUploaderWrapper {
 
     public void uploadStringFinalLog(String message, FinalLogUploader logUploader) {
         try {
-            userLogger.info("Sending final log '{}' into Bifrost", message);
+            userLogger.info("Sending final log into Bifrost");
             bifrostLogUploader.uploadString(message, computeLogMetadata(logUploader));
         } catch (BifrostUploadException ex) {
             throw new BifrostUploadException("Unable to upload string log to Bifrost, log was: " + message, ex);
@@ -45,9 +51,13 @@ public class BifrostLogUploaderWrapper {
     }
 
     public void uploadFileFinalLog(Path finalLogFilePath, FinalLogUploader logUploader) throws BifrostUploadException {
-        try {
-            userLogger.info("Sending final log from the file '{}' into Bifrost", finalLogFilePath);
-            bifrostLogUploader.uploadFile(finalLogFilePath.toFile(), computeLogMetadata(logUploader));
+        Path finalLogTransformedPath = Path.of("/tmp", "final-log-transformed.txt");
+        try (AutoCloseable _c = IOUtils.createFileAutoCloseable(finalLogTransformedPath);
+                BufferedReader br = new BufferedReader(new FileReader(finalLogFilePath.toFile()));
+                BufferedWriter bw = new BufferedWriter(new FileWriter(finalLogTransformedPath.toFile()))) {
+            transformLogs(br, bw);
+            userLogger.info("Sending final log from the file '{}' into Bifrost", finalLogTransformedPath);
+            bifrostLogUploader.uploadFile(finalLogTransformedPath.toFile(), computeLogMetadata(logUploader));
         } catch (BifrostUploadException ex) {
             try {
                 throw new BifrostUploadException(
@@ -59,8 +69,11 @@ public class BifrostLogUploaderWrapper {
             } catch (IOException e) {
                 log.error("Unable to read the file '{}' with the final log.", finalLogFilePath);
                 throw new BifrostUploadException(
-                        String.format("Unable to upload logs from file '%s' to Bifrost", finalLogFilePath));
+                        String.format("Unable to upload logs from file '%s' to Bifrost", finalLogFilePath),
+                        e);
             }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
         }
     }
 
@@ -71,5 +84,20 @@ public class BifrostLogUploaderWrapper {
                 .tag(TagOption.ALIGNMENT_LOG)
                 .endTime(OffsetDateTime.now())
                 .build();
+    }
+
+    private void transformLogs(BufferedReader br, BufferedWriter bw) throws IOException {
+        br.lines().map(originalLine -> {
+            JSONObject jsonObject = new JSONObject(originalLine);
+            return String.format("[%s] %s", jsonObject.getString("level"), jsonObject.getString("message"));
+        }).forEach(str -> {
+            try {
+                bw.write(str);
+                bw.newLine();
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to write: " + str, e);
+            }
+        });
+        bw.flush();
     }
 }


### PR DESCRIPTION
Previously, they were sent as JSONs from the file. Now, the file is modified before the actual send to contain: '[LEVEL] MESSAGE' only, which is human-readable.