### PR TITLE
[NCL-8971]: Reformat final logs

### DIFF
--- a/adjuster/src/main/resources/application.yaml
+++ b/adjuster/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ quarkus:
           path: *final-log-file
           rotation:
             max-file-size: 10G
+          format: '%d{yyyy-MM-dd HH:mm:ss.SSS} [%p] %s%e%n'
     category:
       "org.jboss.pnc._userlog_.alignment-log":
         level: INFO

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentFailureTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentFailureTest.java
@@ -52,7 +52,12 @@ public class AlignmentFailureTest {
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(BIFROST_FINAL_LOG_UPLOAD_PATH))
-                        .withRequestBody(WireMock.containing("Oops, alignment exception")));
+                        .withRequestBody(
+                                WireMock.and(
+                                        WireMock.containing("[INFO] Cloning a repository"),
+                                        WireMock.containing(
+                                                "[WARN] Exception was: org.jboss.pnc.reqour.adjust.exception.AdjusterException: Oops, alignment exception"))));
+
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(CALLBACK_PATH))

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentSuccessTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentSuccessTest.java
@@ -59,10 +59,10 @@ class AlignmentSuccessTest {
                 WireMock.postRequestedFor(WireMock.urlEqualTo(BIFROST_FINAL_LOG_UPLOAD_PATH))
                         .withRequestBody(
                                 WireMock.and(
-                                        WireMock.containing("Cloning a repository"),
+                                        WireMock.containing("[INFO] Cloning a repository"),
                                         WireMock.containing(
-                                                "Starting an alignment process using the corresponding manipulator"),
-                                        WireMock.containing("Pushing aligned changes"))));
+                                                "[INFO] Starting an alignment process using the corresponding manipulator"),
+                                        WireMock.containing("[INFO] Pushing aligned changes"))));
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(CALLBACK_PATH))

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,8 +47,9 @@
             <artifactId>quarkus-logging-kafka-deployment</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
+            <groupId>io.quarkiverse.loggingjson</groupId>
             <artifactId>quarkus-logging-json</artifactId>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Previously, they were sent as JSONs from the file. Now, the file is modified before the actual send to contain: 'DATETIME [LEVEL] MESSAGE' only, which is human-readable.