### PR TITLE
[NCL-9135] Update process stage to ALIGNMENT_ADJUST

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/App.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/App.java
@@ -104,7 +104,7 @@ public class App implements Runnable {
                 cloningResult = repositoryFetcher.cloneRepository(adjustRequest, workdir);
             }
 
-            try (AutoCloseable _c = ProcessStageUtils.startCloseableStage(AdjustProcessStage.ALIGNMENT.name())) {
+            try (AutoCloseable _c = ProcessStageUtils.startCloseableStage(AdjustProcessStage.ALIGNMENT_ADJUST.name())) {
                 AdjustProvider adjustProvider = adjustProviderPicker.pickAdjustProvider(adjustRequest);
                 ManipulatorResult manipulatorResult = adjustProvider.adjust(adjustRequest);
                 AdjustmentPushResult adjustmentPushResult = adjustmentPusher

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentFailureTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentFailureTest.java
@@ -81,12 +81,12 @@ public class AlignmentFailureTest {
                                                 AdjustProcessStage.SCM_CLONE),
                                         AdjustTestUtils.getWireMockContainingPredicate(
                                                 ProcessStageUtils.Step.BEGIN,
-                                                AdjustProcessStage.ALIGNMENT),
+                                                AdjustProcessStage.ALIGNMENT_ADJUST),
                                         WireMock.containing(
                                                 "[INFO] Starting an alignment process using the corresponding manipulator"),
                                         AdjustTestUtils.getWireMockContainingPredicate(
                                                 ProcessStageUtils.Step.END,
-                                                AdjustProcessStage.ALIGNMENT),
+                                                AdjustProcessStage.ALIGNMENT_ADJUST),
                                         WireMock.containing(
                                                 "[WARN] Exception was: org.jboss.pnc.reqour.adjust.exception.AdjusterException: Oops, alignment exception"),
                                         WireMock.notContaining("[INFO] Pushing aligned changes"))));

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentSuccessTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/AlignmentSuccessTest.java
@@ -86,13 +86,13 @@ class AlignmentSuccessTest {
                                                 AdjustProcessStage.SCM_CLONE),
                                         AdjustTestUtils.getWireMockContainingPredicate(
                                                 ProcessStageUtils.Step.BEGIN,
-                                                AdjustProcessStage.ALIGNMENT),
+                                                AdjustProcessStage.ALIGNMENT_ADJUST),
                                         WireMock.containing(
                                                 "[INFO] Starting an alignment process using the corresponding manipulator"),
                                         WireMock.containing("[INFO] Pushing aligned changes"),
                                         AdjustTestUtils.getWireMockContainingPredicate(
                                                 ProcessStageUtils.Step.END,
-                                                AdjustProcessStage.ALIGNMENT))));
+                                                AdjustProcessStage.ALIGNMENT_ADJUST))));
         wireMock.verifyThat(
                 1,
                 WireMock.postRequestedFor(WireMock.urlEqualTo(CALLBACK_PATH))

--- a/core/src/main/java/org/jboss/pnc/reqour/enums/AdjustProcessStage.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/enums/AdjustProcessStage.java
@@ -6,5 +6,5 @@ package org.jboss.pnc.reqour.enums;
 
 public enum AdjustProcessStage {
 
-    STARTING_ALIGNMENT_POD, SCM_CLONE, ALIGNMENT,
+    STARTING_ALIGNMENT_POD, SCM_CLONE, ALIGNMENT_ADJUST,
 }


### PR DESCRIPTION
This is done because Repour originally used the 'ALIGNMENT_ADJUST' [name](https://github.com/project-ncl/repour/blob/0ad23de2733516eaf33c8e422e7dffd4d739fa60/repour/adjust/adjust.py#L279) and we should keep using the same name for build metrics continuity