### PR TITLE
[NCL-9133] Fix typo for manipulation.json

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/GradleProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/GradleProvider.java
@@ -177,6 +177,6 @@ public class GradleProvider extends AbstractAdjustProvider<GmeConfig> implements
     private Path getPathToAlignmentResultFile() {
         return CommonManipulatorResultExtractor.getAlignmentResultsFilePath(
                 config.getWorkdir().resolve("build/alignmentReport.json"),
-                config.getWorkdir().resolve("manipulations.json"));
+                config.getWorkdir().resolve("manipulation.json"));
     }
 }


### PR DESCRIPTION
For Gradle alignment, the file 'manipulation.json' is also produced. This commit fixes the typo where previously we were looking for 'manipulations.json'