### PR TITLE
[NCLSUP-1291] Specify specific version of help plugin to be used

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/MvnProvider.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/provider/MvnProvider.java
@@ -222,7 +222,8 @@ public class MvnProvider extends AbstractAdjustProvider<PmeConfig> implements Ad
     private PME getResultWhenPmeIsDisabled() {
         PME manipulatorResult = new PME();
         GAV gav = new GAV();
-        org.jboss.pnc.api.dto.GAV executionRootGav = rootGavExtractor.extractGav(config.getWorkdir());
+        org.jboss.pnc.api.dto.GAV executionRootGav = rootGavExtractor
+                .extractGav(config.getSubFolderWithAlignmentResultFile());
         gav.setGroupId(executionRootGav.getGroupId());
         gav.setArtifactId(executionRootGav.getArtifactId());
         gav.setVersion(executionRootGav.getVersion());

--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RootGavExtractor.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RootGavExtractor.java
@@ -42,6 +42,7 @@ public class RootGavExtractor {
     private final Path groupIdOutput = resultsDirectory.resolve("groupId.txt");
     private final Path artifactIdOutput = resultsDirectory.resolve("artifactId.txt");
     private final Path versionOutput = resultsDirectory.resolve("version.txt");
+    private static final String HELP_PLUGIN_VERSION = "3.3.0"; // has to be compliant with maven version running in adjuster container https://maven.apache.org/plugins/maven-help-plugin/plugin-info.html
 
     /**
      * Extract the GAV from (effective) pom within the given working directory.
@@ -51,7 +52,8 @@ public class RootGavExtractor {
     public GAV extractGav(Path workdir) {
         log.debug("Extracting GAV from POM in directory '{}'", workdir);
         ProcessContext.Builder processContextBuilder = ProcessContext.defaultBuilderWithWorkdir(workdir)
-                .stdoutConsumer(IOUtils::ignoreOutput);
+                .stdoutConsumer(IOUtils::ignoreOutput)
+                .stderrConsumer(log::warn);
 
         int exitCode = 0;
         exitCode += processExecutor
@@ -82,6 +84,11 @@ public class RootGavExtractor {
     }
 
     private List<String> generateHelpEvaluateCommand(String property, Path outputFile) {
-        return List.of(mavenExecutable, "help:evaluate", "-Dexpression=project." + property, "-Doutput=" + outputFile);
+        return List.of(
+                mavenExecutable,
+                "-V",
+                "org.apache.maven.plugins:maven-help-plugin:" + HELP_PLUGIN_VERSION + ":evaluate",
+                "-Dexpression=project." + property,
+                "-Doutput=" + outputFile);
     }
 }


### PR DESCRIPTION
When extracting GAV from pom.xml, this can cause problems with incompatible (default) maven version running in adjuster pod. Since maven 3.5.4 is used as the default one in time when commiting this, we force help plugin 3.3.0, which is compatible with this maven version.