### PR TITLE
[NCLSUP-1296] Parse pom.xml project.parent if field missing

### DIFF
--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/service/RootGavExtractorTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/service/RootGavExtractorTest.java
@@ -52,4 +52,17 @@ class RootGavExtractorTest {
 
         assertThat(gav).isEqualTo(expectedGav);
     }
+
+    @Test
+    void extractGav_withParentOnlyGroupIdVersion() {
+        Path workdir = GAV_EXTRACTOR_TEST_DIR.resolve("with-parent-only-groupid-version");
+        GAV expectedGav = GAV.builder()
+                .ga(GA.builder().groupId("com.example").artifactId("bar").build())
+                .version("1.0.0.rh-69")
+                .build();
+
+        GAV gav = rootGavExtractor.extractGav(workdir);
+
+        assertThat(gav).isEqualTo(expectedGav);
+    }
 }

--- a/adjuster/src/test/resources/service/gav-extractor/with-parent-only-groupid-version/pom.xml
+++ b/adjuster/src/test/resources/service/gav-extractor/with-parent-only-groupid-version/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>foo</artifactId>
+        <version>1.0.0.rh-69</version>
+    </parent>
+    <artifactId>bar</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
For the scenario where PME is disabled, we read from the pom.xml to extract the project's groupId, artifactId, and version.

In case the project's groupId and/or version is missing, we read it from the project parent's groupId and/or version instead.

This commit also changes the way we extract the data by directly parsing the Maven's pom.xml as an XML file instead of relying on Maven's maven-help-plugin since it might fail when the parent cannot be downloaded easily.