### PR TITLE
Fix gitSubmoduleLocations regex

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RepositoryFetcherImpl.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RepositoryFetcherImpl.java
@@ -228,11 +228,12 @@ public class RepositoryFetcherImpl implements RepositoryFetcher {
         gitCommands.commit("Removing submodules and transforming into fat repository", processContextBuilder);
     }
 
-    private static List<String> getSubmoduleLocations(Path submodulesFile) {
+    static List<String> getSubmoduleLocations(Path submodulesFile) {
         String pathPrefix = "path =";
         try (BufferedReader br = new BufferedReader(new FileReader(submodulesFile.toFile()))) {
+            // we don't use \w+ to get the path since the path might contain a slash, which is not a word character
             return br.lines()
-                    .filter(l -> l.matches(String.format("^\\s+%s \\w+$", pathPrefix)))
+                    .filter(l -> l.matches(String.format("^\\s+%s \\S+$", pathPrefix)))
                     .map(l -> l.replace(pathPrefix, "").stripLeading())
                     .toList();
         } catch (IOException e) {

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/service/RepositoryFetcherTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/service/RepositoryFetcherTest.java
@@ -8,11 +8,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.jboss.pnc.reqour.common.utils.IOUtils.createTempDir;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
 import jakarta.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.jboss.pnc.api.reqour.dto.AdjustRequest;
 import org.jboss.pnc.api.reqour.dto.InternalGitRepositoryUrl;
 import org.jboss.pnc.reqour.adjust.common.RepoInitializer;
@@ -131,5 +135,23 @@ class RepositoryFetcherTest {
         CloningResult actualCloningResult = repositoryFetcher.cloneRepository(adjustRequest, workdir);
 
         assertThat(actualCloningResult).isEqualTo(expectedCloningResult);
+    }
+
+    @Test
+    void testSubmoduleParsing() throws Exception {
+        URL url = IOUtils.resourceToURL("/git-files/gitmodule");
+        Path path = Paths.get(url.toURI());
+        List<String> submoduleLocations = RepositoryFetcherImpl.getSubmoduleLocations(path);
+        assertThat(submoduleLocations).hasSize(1);
+        assertThat(submoduleLocations.get(0)).isEqualTo("submodules/quarkus");
+
+        // now testing for multiple submodules
+        url = IOUtils.resourceToURL("/git-files/gitmodule-multi");
+        path = Paths.get(url.toURI());
+        submoduleLocations = RepositoryFetcherImpl.getSubmoduleLocations(path);
+        assertThat(submoduleLocations).hasSize(2);
+        assertThat(submoduleLocations.get(0)).isEqualTo("submodules/quarkus");
+        assertThat(submoduleLocations.get(1)).isEqualTo("submodules/quarkus-behive/test");
+
     }
 }

--- a/adjuster/src/test/resources/git-files/gitmodule
+++ b/adjuster/src/test/resources/git-files/gitmodule
@@ -1,0 +1,3 @@
+[submodule "submodules/quarkus"]
+       path = submodules/quarkus
+       url = https://github.com/quarkusio/quarkus

--- a/adjuster/src/test/resources/git-files/gitmodule-multi
+++ b/adjuster/src/test/resources/git-files/gitmodule-multi
@@ -1,0 +1,6 @@
+[submodule "submodules/quarkus"]
+       path = submodules/quarkus
+       url = https://github.com/quarkusio/quarkus
+[submodule "submodules/quarkus-behive/test"]
+       path = submodules/quarkus-behive/test
+       url = https://github.com/quarkusio/quarkus


### PR DESCRIPTION
The `gitSubmoduleLocations` method didn't parse properly the gitmodules file if the path contained a slash (/).

This commit fixes it by using a different regex, and provides a test for different scenarios.