### PR TITLE
[NCL-9244] Map Gitlab-related exceptions as FAILED

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/App.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/App.java
@@ -30,6 +30,7 @@ import org.jboss.pnc.reqour.adjust.service.AdjustmentPusher;
 import org.jboss.pnc.reqour.adjust.service.RepositoryFetcher;
 import org.jboss.pnc.reqour.adjust.utils.CommonUtils;
 import org.jboss.pnc.reqour.common.exceptions.GitException;
+import org.jboss.pnc.reqour.common.exceptions.GitlabApiRuntimeException;
 import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.jboss.pnc.reqour.enums.AdjustProcessStage;
 import org.jboss.pnc.reqour.enums.FinalLogUploader;
@@ -121,13 +122,8 @@ public class App implements Runnable {
                         adjustResponseBuilder,
                         manipulatorResult);
             }
-        } catch (AdjusterException e) {
-            log.warn("Alignment exception occurred, setting the status to FAILED");
-            userLogger.warn("Exception was: {}", e.getMessage(), e);
-            adjustResponseBuilder.callback(
-                    ReqourCallback.builder().id(adjustRequest.getTaskId()).status(ResultStatus.FAILED).build());
-        } catch (GitException e) {
-            log.warn("Git exception occurred, setting the status to FAILED");
+        } catch (AdjusterException | GitException | GitlabApiRuntimeException e) {
+            log.warn("{} exception occurred, setting the status to FAILED", e.getClass().getSimpleName());
             userLogger.warn("Exception was: {}", e.getMessage(), e);
             adjustResponseBuilder.callback(
                     ReqourCallback.builder().id(adjustRequest.getTaskId()).status(ResultStatus.FAILED).build());

--- a/adjuster/src/main/resources/application-test.yaml
+++ b/adjuster/src/main/resources/application-test.yaml
@@ -1,6 +1,10 @@
 quarkus:
   oidc-client:
     enabled: false
+  log:
+    category:
+      "org.jboss.pnc._userlog_":
+        level: DEBUG
 
 reqour-adjuster:
   adjust:

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/GitlabExceptionTest.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/GitlabExceptionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust;
+
+import static org.jboss.pnc.api.constants.HttpHeaders.CONTENT_TYPE_STRING;
+import static org.jboss.pnc.reqour.common.TestDataSupplier.BIFROST_FINAL_LOG_UPLOAD_PATH;
+import static org.jboss.pnc.reqour.common.TestDataSupplier.CALLBACK_PATH;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+
+import org.jboss.pnc.api.enums.ResultStatus;
+import org.jboss.pnc.api.reqour.dto.AdjustResponse;
+import org.jboss.pnc.api.reqour.dto.ReqourCallback;
+import org.jboss.pnc.common.log.ProcessStageUtils;
+import org.jboss.pnc.reqour.adjust.profile.WithGitlabExceptionAlternative;
+import org.jboss.pnc.reqour.enums.AdjustProcessStage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkiverse.wiremock.devservice.ConnectWireMock;
+import io.quarkus.picocli.runtime.annotations.TopCommand;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(WithGitlabExceptionAlternative.class)
+@ConnectWireMock
+public class GitlabExceptionTest {
+
+    @Inject
+    @TopCommand
+    App app;
+
+    WireMock wireMock;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Inject
+    AdjustTestUtils adjustTestUtils;
+
+    @BeforeEach
+    void setUp() {
+        wireMock.register(WireMock.post(BIFROST_FINAL_LOG_UPLOAD_PATH).willReturn(WireMock.ok()));
+        wireMock.register(WireMock.post(CALLBACK_PATH).willReturn(WireMock.ok()));
+        wireMock.register(WireMock.post(adjustTestUtils.getHeartbeatPath()).willReturn(WireMock.ok()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMock.resetRequests();
+    }
+
+    @Test
+    void run_gitException_finalLogAndCallbackSent() throws InterruptedException, JsonProcessingException {
+        app.run();
+
+        Thread.sleep(2_000);
+        wireMock.verifyThat(
+                1,
+                WireMock.postRequestedFor(WireMock.urlEqualTo(BIFROST_FINAL_LOG_UPLOAD_PATH))
+                        .withRequestBody(
+                                WireMock.and(
+                                        AdjustTestUtils.getWireMockContainingPredicate(
+                                                ProcessStageUtils.Step.END,
+                                                AdjustProcessStage.STARTING_ALIGNMENT_POD),
+                                        AdjustTestUtils.getWireMockContainingPredicate(
+                                                ProcessStageUtils.Step.BEGIN,
+                                                AdjustProcessStage.SCM_CLONE),
+                                        WireMock.containing("[INFO] Cloning a repository"),
+                                        WireMock.containing("[DEBUG] Checking tag protection"),
+                                        AdjustTestUtils.getWireMockContainingPredicate(
+                                                ProcessStageUtils.Step.END,
+                                                AdjustProcessStage.SCM_CLONE),
+                                        WireMock.containing(
+                                                "[WARN] Exception was: org.gitlab4j.api.GitLabApiException: Project not found"),
+                                        WireMock.notContaining(
+                                                "[INFO] Starting an alignment process using the corresponding manipulator"),
+                                        WireMock.notContaining("[INFO] Pushing aligned changes"))));
+
+        wireMock.verifyThat(
+                1,
+                WireMock.postRequestedFor(WireMock.urlEqualTo(CALLBACK_PATH))
+                        .withHeader(CONTENT_TYPE_STRING, WireMock.equalTo(MediaType.APPLICATION_JSON))
+                        .withRequestBody(
+                                WireMock.equalToJson(
+                                        objectMapper.writeValueAsString(
+                                                AdjustResponse.builder()
+                                                        .callback(
+                                                                ReqourCallback.builder()
+                                                                        .id("task123")
+                                                                        .status(ResultStatus.FAILED)
+                                                                        .build())
+                                                        .build()))));
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/alternatives/FailingRepositoryFetcherMock2.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/alternatives/FailingRepositoryFetcherMock2.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.alternatives;
+
+import java.nio.file.Path;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+
+import org.gitlab4j.api.GitLabApiException;
+import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.adjust.model.CloningResult;
+import org.jboss.pnc.reqour.adjust.service.RepositoryFetcher;
+import org.jboss.pnc.reqour.common.exceptions.GitlabApiRuntimeException;
+import org.jboss.pnc.reqour.runtime.UserLogger;
+import org.slf4j.Logger;
+
+@Alternative
+@ApplicationScoped
+public class FailingRepositoryFetcherMock2 implements RepositoryFetcher {
+
+    @Inject
+    @UserLogger
+    Logger userLogger;
+
+    @Override
+    public CloningResult cloneRepository(AdjustRequest adjustRequest, Path workdir) {
+        userLogger.info("Cloning a repository");
+        userLogger.debug("Checking tag protection");
+        throw new GitlabApiRuntimeException(new GitLabApiException("Project not found"));
+    }
+}

--- a/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profile/WithGitlabExceptionAlternative.java
+++ b/adjuster/src/test/java/org/jboss/pnc/reqour/adjust/profile/WithGitlabExceptionAlternative.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Red Hat, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.pnc.reqour.adjust.profile;
+
+import java.util.Set;
+
+import org.jboss.pnc.reqour.adjust.alternatives.AdjustProviderMock;
+import org.jboss.pnc.reqour.adjust.alternatives.AdjustProviderPickerMock;
+import org.jboss.pnc.reqour.adjust.alternatives.AdjustmentPusherMock;
+import org.jboss.pnc.reqour.adjust.alternatives.FailingRepositoryFetcherMock2;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class WithGitlabExceptionAlternative implements QuarkusTestProfile {
+
+    @Override
+    public Set<Class<?>> getEnabledAlternatives() {
+        return Set.of(
+                AdjustProviderPickerMock.class,
+                AdjustProviderMock.class,
+                FailingRepositoryFetcherMock2.class,
+                AdjustmentPusherMock.class);
+    }
+}


### PR DESCRIPTION
Previously, these exceptions were mapped as system errors