### PR TITLE
[NCL-9242] Escape '$' from shell, but unescape from Java

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/converter/AdjustRequestConverter.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/config/converter/AdjustRequestConverter.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 
 import org.eclipse.microprofile.config.spi.Converter;
 import org.jboss.pnc.api.reqour.dto.AdjustRequest;
+import org.jboss.pnc.reqour.common.utils.IOUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -25,9 +26,11 @@ public class AdjustRequestConverter implements Converter<AdjustRequest> {
     ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public AdjustRequest convert(String value) throws IllegalArgumentException, NullPointerException {
+    public AdjustRequest convert(String serializedAdjustRequestInJson)
+            throws IllegalArgumentException, NullPointerException {
         try {
-            return objectMapper.readValue(value, AdjustRequest.class);
+            return IOUtils.unescapeUserAlignmentParameters(
+                    objectMapper.readValue(serializedAdjustRequestInJson, AdjustRequest.class));
         } catch (IOException e) {
             throw new RuntimeException("Error occurred when reading the request from ADJUST_REQUEST env variable", e);
         }

--- a/core/src/main/java/org/jboss/pnc/reqour/common/utils/IOUtils.java
+++ b/core/src/main/java/org/jboss/pnc/reqour/common/utils/IOUtils.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -81,19 +80,7 @@ public class IOUtils {
         return (text.startsWith("\"") && text.endsWith("\"")) ? text.substring(1, text.length() - 1) : text;
     }
 
-    public static AdjustRequest escapeUserAlignmentParameters(AdjustRequest adjustRequest) {
-        return adjustUserAlignmentParameters(adjustRequest, s -> s.replace("$", "\\$"));
-    }
-
     public static AdjustRequest unescapeUserAlignmentParameters(AdjustRequest adjustRequest) {
-        // Why not unescaping only '\$'?
-        // Because reqour-rest sends adjust request as env variable which is serialized in JSON format. And since escaping '-Dfoo=${VAR}' is: '-Dfoo=\${VAR}', there is one extra escaping done because of JSON nature: '\$' -> '\\$'. Hence, after reqour-rest escaping and JSON escaping, '${VAR}' is '\\${VAR}'.
-        return adjustUserAlignmentParameters(adjustRequest, s -> s.replace("\\\\$", "$"));
-    }
-
-    private static AdjustRequest adjustUserAlignmentParameters(
-            AdjustRequest adjustRequest,
-            Function<String, String> adjuster) {
         if (adjustRequest.getBuildConfigParameters() == null) {
             return adjustRequest;
         }
@@ -105,7 +92,7 @@ public class IOUtils {
             return adjustRequest;
         }
 
-        String adjustedUserAlignmentParameters = adjuster.apply(userAlignmentParameters);
+        String adjustedUserAlignmentParameters = userAlignmentParameters.replace("\\$", "$");
         buildConfigParameters
                 .put(BuildConfigurationParameterKeys.ALIGNMENT_PARAMETERS, adjustedUserAlignmentParameters);
 

--- a/core/src/test/java/org/jboss/pnc/reqour/common/utils/IOUtilsTest.java
+++ b/core/src/test/java/org/jboss/pnc/reqour/common/utils/IOUtilsTest.java
@@ -69,53 +69,6 @@ class IOUtilsTest {
     }
 
     @Test
-    void escapeUserAlignmentParameters_noBuildConfigParameters_returnsUnchanged() {
-        AdjustRequest adjustRequest = AdjustRequest.builder()
-                .build();
-
-        assertThat(IOUtils.escapeUserAlignmentParameters(adjustRequest)).isEqualTo(adjustRequest);
-    }
-
-    @Test
-    void escapeUserAlignmentParameters_noUserAlignmentParameters_returnsUnchanged() {
-        AdjustRequest adjustRequest = AdjustRequest.builder()
-                .buildConfigParameters(Collections.emptyMap())
-                .build();
-
-        assertThat(IOUtils.escapeUserAlignmentParameters(adjustRequest)).isEqualTo(adjustRequest);
-    }
-
-    @Test
-    void escapeUserAlignmentParameters_userAlignmentParametersWithoutDollars_returnsUnchanged() {
-        AdjustRequest adjustRequest = AdjustRequest.builder()
-                .buildType(BuildType.MVN)
-                .buildConfigParameters(Map.of(BuildConfigurationParameterKeys.ALIGNMENT_PARAMETERS, "-Dfoo=bar"))
-                .build();
-
-        assertThat(IOUtils.escapeUserAlignmentParameters(adjustRequest)).isEqualTo(adjustRequest);
-    }
-
-    @Test
-    void escapeUserAlignmentParameters_userAlignmentParametersWithDollars_returnsEscaped() {
-        AdjustRequest adjustRequest = AdjustRequest.builder()
-                .buildType(BuildType.MVN)
-                .buildConfigParameters(
-                        Map.of(
-                                BuildConfigurationParameterKeys.ALIGNMENT_PARAMETERS,
-                                "-Dfoo=bar '-DaddDependency.io.netty:netty-transport-native-epoll:${netty.version}:compile:linux-x86_64@flink-shaded-netty-4'"))
-                .build();
-        AdjustRequest escapedRequest = AdjustRequest.builder()
-                .buildType(BuildType.MVN)
-                .buildConfigParameters(
-                        Map.of(
-                                BuildConfigurationParameterKeys.ALIGNMENT_PARAMETERS,
-                                "-Dfoo=bar '-DaddDependency.io.netty:netty-transport-native-epoll:\\${netty.version}:compile:linux-x86_64@flink-shaded-netty-4'"))
-                .build();
-
-        assertThat(IOUtils.escapeUserAlignmentParameters(adjustRequest)).isEqualTo(escapedRequest);
-    }
-
-    @Test
     void unescapeUserAlignmentParameters_noBuildConfigParameters_returnsUnchanged() {
         AdjustRequest adjustRequest = AdjustRequest.builder()
                 .build();
@@ -149,7 +102,7 @@ class IOUtilsTest {
                 .buildConfigParameters(
                         Map.of(
                                 BuildConfigurationParameterKeys.ALIGNMENT_PARAMETERS,
-                                "-Dfoo=bar '-DaddDependency.io.netty:netty-transport-native-epoll:\\\\${netty.version}:compile:linux-x86_64@flink-shaded-netty-4'"))
+                                "-Dfoo=bar '-DaddDependency.io.netty:netty-transport-native-epoll:\\${netty.version}:compile:linux-x86_64@flink-shaded-netty-4'"))
                 .build();
         AdjustRequest unescapedRequest = AdjustRequest.builder()
                 .buildType(BuildType.MVN)

--- a/rest/src/main/java/org/jboss/pnc/reqour/rest/openshift/JobDefinitionCreator.java
+++ b/rest/src/main/java/org/jboss/pnc/reqour/rest/openshift/JobDefinitionCreator.java
@@ -17,7 +17,6 @@ import org.apache.commons.text.StringSubstitutor;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.pnc.api.constants.BuildConfigurationParameterKeys;
 import org.jboss.pnc.api.reqour.dto.AdjustRequest;
-import org.jboss.pnc.reqour.common.utils.IOUtils;
 import org.jboss.pnc.reqour.config.ReqourConfig;
 import org.jboss.pnc.reqour.rest.config.ReqourRestConfig;
 import org.jboss.pnc.reqour.runtime.UserLogger;
@@ -131,6 +130,6 @@ public class JobDefinitionCreator {
     }
 
     String prepareAdjustRequest(AdjustRequest adjustRequest) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(IOUtils.escapeUserAlignmentParameters(adjustRequest));
+        return objectMapper.writeValueAsString(adjustRequest);
     }
 }

--- a/rest/src/test/java/org/jboss/pnc/reqour/rest/openshift/JobDefinitionCreatorTest.java
+++ b/rest/src/test/java/org/jboss/pnc/reqour/rest/openshift/JobDefinitionCreatorTest.java
@@ -195,7 +195,7 @@ class JobDefinitionCreatorTest {
     }
 
     @Test
-    void prepareAdjustRequest_userAlignmentParametersWithDollars_returnsEscaped() throws JsonProcessingException {
+    void prepareAdjustRequest_userAlignmentParametersWithDollars_returnsUnchanged() throws JsonProcessingException {
         assertThat(
                 jobDefinitionCreator.prepareAdjustRequest(
                         AdjustRequest.builder()
@@ -208,7 +208,8 @@ class JobDefinitionCreatorTest {
                                 .taskId("task-id")
                                 .build()))
                 .isEqualTo(
-                        // Note: since we escape '$' -> '\$', it will be escaped as '\\$' in json (since escaping '\' is done as '\\').
-                        "{\"internalUrl\":null,\"ref\":null,\"callback\":null,\"sync\":false,\"originRepoUrl\":null,\"buildConfigParameters\":{\"ALIGNMENT_PARAMETERS\":\"-Dfoo=bar '-DaddDependency.io.netty:netty-transport-native-epoll:\\\\${netty.version}:compile:linux-x86_64@flink-shaded-netty-4'\"},\"tempBuild\":false,\"alignmentPreference\":null,\"buildType\":\"MVN\",\"pncDefaultAlignmentParameters\":null,\"brewPullActive\":true,\"taskId\":\"task-id\",\"heartbeatConfig\":null}");
+                        // Note: escaping is done from shell (see start script of adjuster image) in order to have '$' escaped as '\$'
+                        //       because in case we would do it from Java, we would escape '$' to '\$' and then jackson would escape '\' once more, so it would be '\\$'
+                        "{\"internalUrl\":null,\"ref\":null,\"callback\":null,\"sync\":false,\"originRepoUrl\":null,\"buildConfigParameters\":{\"ALIGNMENT_PARAMETERS\":\"-Dfoo=bar '-DaddDependency.io.netty:netty-transport-native-epoll:${netty.version}:compile:linux-x86_64@flink-shaded-netty-4'\"},\"tempBuild\":false,\"alignmentPreference\":null,\"buildType\":\"MVN\",\"pncDefaultAlignmentParameters\":null,\"brewPullActive\":true,\"taskId\":\"task-id\",\"heartbeatConfig\":null}");
     }
 }


### PR DESCRIPTION
Previously, both escaping and unescaping were done from within the Java. Now, only unescaping is done from Java (as part of adjuster codebase when adjust request is being deserialized from JSON).

**Why was escaping removed?**
Because escaping '$' from Java means changing it into '\$'. However, there is also another escaping (this time, escaping of '\' of the '\$' sequence) taking place, which is done by Jackson. Hence, '$' is after serialization into JSON represented as '\\\\$'. When deserialization into [AdjustRequest](https://github.com/project-ncl/pnc-api/blob/db80589f91e50335040282ecbe996f59b3e1a9c8/src/main/java/org/jboss/pnc/api/reqour/dto/AdjustRequest.java#L33) takes place, this causes a failure to start Quarkus application because of the '\\\\$' sequence.
Serialization from shell guarantees that seriazliation is done as '\$' (not as '\\\\$') which causes no failure during Quarkus app startup.