### PR TITLE
Return null GAV for RootGavExtractor if file doesn't exist

### DIFF
--- a/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RootGavExtractor.java
+++ b/adjuster/src/main/java/org/jboss/pnc/reqour/adjust/service/RootGavExtractor.java
@@ -37,6 +37,12 @@ public class RootGavExtractor {
     public GAV extractGav(Path workdir) {
         log.debug("Extracting GAV from POM in directory '{}'", workdir);
         File pom = workdir.resolve("pom.xml").toFile();
+
+        if (!pom.exists()) {
+            log.warn("File {} doesn't exist", pom);
+            return GAV.builder().ga(GA.builder().artifactId(null).groupId(null).build()).version(null).build();
+        }
+
         String groupId = null;
         String artifactId = null;
         String version = null;


### PR DESCRIPTION
If the pom.xml doesn't exist, which may happen for some extreme scenarios, instead of failing, we just return a GAV object with null groupId, artifactId, and version instead.